### PR TITLE
feat: user-packages and system-packages batteries

### DIFF
--- a/modules/aspects/batteries/pkgs.nix
+++ b/modules/aspects/batteries/pkgs.nix
@@ -31,10 +31,10 @@ let
     };
 
   userPackages =
-    getPkgs: user:
+    getPkgs:
     let
-      nixos = { pkgs, ... }: {
-        users.users.${user.userName}.packages = getPkgs pkgs;
+      nixos = { user, pkgs, ... }: {
+        users.users.${user.name}.packages = getPkgs pkgs;
       };
       darwin = nixos;
     in
@@ -55,8 +55,8 @@ let
 
   to-host = getPkgs: { host, ... }: hostPackages getPkgs;
   to-host-only = getPkgs: { host }: hostPackages getPkgs;
-  to-user = getPkgs: { host, user }: userPackages getPkgs user;
-  to-home = getPkgs: { home }: homePackages getPkgs;
+  to-user = userPackages;
+  to-home = homePackages;
 
   __functor = _self: getPkgs: {
       includes = [

--- a/modules/aspects/batteries/pkgs.nix
+++ b/modules/aspects/batteries/pkgs.nix
@@ -1,0 +1,77 @@
+{ den, ... }:
+let
+  description = ''
+    Includes a package at User and Home levels.
+
+    Works in NixOS/Darwin and standalone Home-Manager
+
+    ## Usage
+
+       # for NixOS/Darwin
+       den.aspects.my-user.includes = [ (den._.user-packages [ "hello" ]) ]
+
+       # for standalone home-manager
+       den.aspects.my-home.includes = [ den._.user-packages [ "hello" ]) ]
+
+    or globally (automatically applied depending on context):
+
+       den.default.includes = [ den._.user-packages [ "hello" ]) ]
+  '';
+
+  hostPackages =
+    getPkgs:
+    let
+      nixos = { pkgs, ... }: {
+        environment.systemPackages = getPkgs pkgs;
+      };
+      darwin = nixos;
+    in
+    {
+      inherit nixos darwin;
+    };
+
+  userPackages =
+    getPkgs: user:
+    let
+      nixos = { pkgs, ... }: {
+        users.users.${user.userName}.packages = getPkgs pkgs;
+      };
+      darwin = nixos;
+    in
+    {
+      inherit nixos darwin;
+    };
+
+  homePackages =
+    getPkgs:
+    let
+      homeManager = { pkgs, ... }: {
+        home.packages = getPkgs pkgs;
+      };
+    in
+    {
+      inherit homeManager;
+    };
+
+  to-host = getPkgs: { host, ... }: hostPackages getPkgs;
+  to-host-only = getPkgs: { host }: hostPackages getPkgs;
+  to-user = getPkgs: { host, user }: userPackages getPkgs user;
+  to-home = getPkgs: { home }: homePackages getPkgs;
+
+  __functor = _self: getPkgs: {
+      includes = [
+        (to-host-only getPkgs)
+        (to-user getPkgs)
+        (to-home getPkgs)
+      ];
+    };
+
+in
+{
+  den.batteries.pkgs = {
+    inherit description __functor;
+    provides = {
+      inherit to-host to-user to-home;
+    };
+  };
+}

--- a/modules/aspects/batteries/pkgs.nix
+++ b/modules/aspects/batteries/pkgs.nix
@@ -69,9 +69,11 @@ let
 in
 {
   den.batteries.pkgs = {
-    inherit description __functor;
-    provides = {
-      inherit to-host to-user to-home;
-    };
+    inherit
+      description
+      __functor
+      to-host
+      to-user
+      to-home;
   };
 }

--- a/templates/ci/modules/features/pkgs.nix
+++ b/templates/ci/modules/features/pkgs.nix
@@ -1,0 +1,74 @@
+{ denTest, ... }:
+{
+  flake.tests.pkgs = {
+
+    test-pkgs-set-on-host = denTest (
+      { den, igloo, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+        den.aspects.igloo.includes = [ (den._.pkgs (pkgs: pkgs.discord)) ];
+
+        expr = igloo.config.environment.systemPackages;
+        expected = [ "discord" ];
+      }
+    );
+
+    test-pkgs-set-on-user = denTest (
+      { den, igloo, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+        den.aspects.tux.includes = [ (den._.pkgs (pkgs: pkgs.discord)) ];
+
+        expr = igloo.config.users.users.tux.packages;
+        expected = [ "discord" ];
+      }
+    );
+
+    test-pkgs-set-on-home-manager = denTest (
+      { den, tuxHm, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+        den.default.homeManager.home.stateVersion = "25.11";
+        den.aspects.tux.includes = [ (den._.pkgs (pkgs: pkgs.discord)) ];
+
+        expr = tuxHm.config.home.packages;
+        expected = [ "discord" ];
+      }
+    );
+
+    test-pkgs-to-host-set-on-host = denTest (
+      { den, igloo, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+        den.aspects.tux.includes = [ (den._.pkgs._.to-host (pkgs: pkgs.discord)) ];
+
+        expr = igloo.config.environment.systemPackages;
+        expected = [ "discord" ];
+      }
+    );
+
+    test-pkgs-to-user-set-on-user = denTest (
+      { den, igloo, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+        den.aspects.tux.includes = [ (den._.pkgs._.to-user (pkgs: pkgs.discord)) ];
+
+        expr = igloo.config.users.users.tux.packages;
+        expected = [ "discord" ];
+      }
+    );
+
+    test-pkgs-to-home-set-on-home-manager = denTest (
+      { den, tuxHm, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+        den.default.homeManager.home.stateVersion = "25.11";
+        den.aspects.tux.includes = [ (den._.pkgs._.to-home (pkgs: pkgs.discord)) ];
+
+        expr = tuxHm.config.home.packages;
+        expected = [ "discord" ];
+      }
+    );
+
+  };
+}

--- a/templates/ci/modules/features/pkgs.nix
+++ b/templates/ci/modules/features/pkgs.nix
@@ -6,10 +6,10 @@
       { den, igloo, ... }:
       {
         den.hosts.x86_64-linux.igloo.users.tux = { };
-        den.aspects.igloo.includes = [ (den._.pkgs (pkgs: pkgs.discord)) ];
+        den.aspects.igloo.includes = [ (den.batteries.pkgs (pkgs: [pkgs.hello])) ];
 
-        expr = igloo.config.environment.systemPackages;
-        expected = [ "discord" ];
+        expr = builtins.elem "hello" (builtins.map (pkg: (builtins.head (builtins.splitVersion pkg.name))) igloo.environment.systemPackages);
+        expected = true;
       }
     );
 
@@ -17,10 +17,10 @@
       { den, igloo, ... }:
       {
         den.hosts.x86_64-linux.igloo.users.tux = { };
-        den.aspects.tux.includes = [ (den._.pkgs (pkgs: pkgs.discord)) ];
+        den.aspects.tux.includes = [ (den.batteries.pkgs (pkgs: [pkgs.hello])) ];
 
-        expr = igloo.config.users.users.tux.packages;
-        expected = [ "discord" ];
+        expr = builtins.elem "hello" (builtins.map (pkg: pkg.pname) igloo.users.users.tux.packages);
+        expected = true;
       }
     );
 
@@ -29,10 +29,10 @@
       {
         den.hosts.x86_64-linux.igloo.users.tux = { };
         den.default.homeManager.home.stateVersion = "25.11";
-        den.aspects.tux.includes = [ (den._.pkgs (pkgs: pkgs.discord)) ];
+        den.aspects.tux.includes = [ (den.batteries.pkgs (pkgs: [pkgs.hello])) ];
 
-        expr = tuxHm.config.home.packages;
-        expected = [ "discord" ];
+        expr = builtins.elem "hello" (builtins.map (pkg: (builtins.head (builtins.splitVersion pkg.name))) tuxHm.home.packages);
+        expected = true;
       }
     );
 
@@ -40,10 +40,10 @@
       { den, igloo, ... }:
       {
         den.hosts.x86_64-linux.igloo.users.tux = { };
-        den.aspects.tux.includes = [ (den._.pkgs._.to-host (pkgs: pkgs.discord)) ];
+        den.aspects.tux.includes = [ (den.batteries.pkgs.to-host (pkgs: [pkgs.hello])) ];
 
-        expr = igloo.config.environment.systemPackages;
-        expected = [ "discord" ];
+        expr = builtins.elem "hello" (builtins.map (pkg: (builtins.head (builtins.splitVersion pkg.name))) igloo.environment.systemPackages);
+        expected = true;
       }
     );
 
@@ -51,10 +51,10 @@
       { den, igloo, ... }:
       {
         den.hosts.x86_64-linux.igloo.users.tux = { };
-        den.aspects.tux.includes = [ (den._.pkgs._.to-user (pkgs: pkgs.discord)) ];
+        den.aspects.tux.includes = [ (den.batteries.pkgs.to-user (pkgs: [pkgs.hello])) ];
 
-        expr = igloo.config.users.users.tux.packages;
-        expected = [ "discord" ];
+        expr = builtins.elem "hello" (builtins.map (pkg: pkg.pname) igloo.users.users.tux.packages);
+        expected = true;
       }
     );
 
@@ -63,10 +63,21 @@
       {
         den.hosts.x86_64-linux.igloo.users.tux = { };
         den.default.homeManager.home.stateVersion = "25.11";
-        den.aspects.tux.includes = [ (den._.pkgs._.to-home (pkgs: pkgs.discord)) ];
+        den.aspects.tux.includes = [ (den.batteries.pkgs.to-home (pkgs: [pkgs.hello])) ];
 
-        expr = tuxHm.config.home.packages;
-        expected = [ "discord" ];
+        expr = builtins.elem "hello" (builtins.map (pkg: (builtins.head (builtins.splitVersion pkg.name))) tuxHm.home.packages);
+        expected = true;
+      }
+    );
+
+    test-pkgs-set-on-user-not-on-host = denTest (
+      { den, igloo, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+        den.aspects.tux.includes = [ (den.batteries.pkgs (pkgs: [pkgs.hello])) ];
+
+        expr = builtins.elem "hello" (builtins.map (pkg: pkg.pname) igloo.users.users.tux.packages);
+        expected = false;
       }
     );
 

--- a/templates/ci/modules/features/pkgs.nix
+++ b/templates/ci/modules/features/pkgs.nix
@@ -27,7 +27,7 @@
     test-pkgs-set-on-home-manager = denTest (
       { den, tuxHm, ... }:
       {
-        den.hosts.x86_64-linux.igloo.users.tux = { };
+        den.hosts.x86_64-linux.igloo.users.tux.classes = [ "homeManager" ];
         den.default.homeManager.home.stateVersion = "25.11";
         den.aspects.tux.includes = [ (den.batteries.pkgs (pkgs: [pkgs.hello])) ];
 
@@ -61,7 +61,7 @@
     test-pkgs-to-home-set-on-home-manager = denTest (
       { den, tuxHm, ... }:
       {
-        den.hosts.x86_64-linux.igloo.users.tux = { };
+        den.hosts.x86_64-linux.igloo.users.tux.classes = [ "homeManager" ];
         den.default.homeManager.home.stateVersion = "25.11";
         den.aspects.tux.includes = [ (den.batteries.pkgs.to-home (pkgs: [pkgs.hello])) ];
 
@@ -74,6 +74,18 @@
       { den, igloo, ... }:
       {
         den.hosts.x86_64-linux.igloo.users.tux = { };
+        den.aspects.tux.includes = [ (den.batteries.pkgs (pkgs: [pkgs.hello])) ];
+
+        expr = builtins.elem "hello" (builtins.map (pkg: (builtins.head (builtins.splitVersion pkg.name))) igloo.environment.systemPackages);
+        expected = false;
+      }
+    );
+
+    test-pkgs-set-on-home-manager-not-on-user = denTest (
+      { den, igloo, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux.classes = [ "homeManager" ];
+        den.default.homeManager.home.stateVersion = "25.11";
         den.aspects.tux.includes = [ (den.batteries.pkgs (pkgs: [pkgs.hello])) ];
 
         expr = builtins.elem "hello" (builtins.map (pkg: pkg.pname) igloo.users.users.tux.packages);


### PR DESCRIPTION
This is a preliminary implementation of the user-packages and system-packages batteries as suggested in [Feature requests braindump](https://github.com/vic/den/discussions/329#discussioncomment-16535450).

These new batteries allow the following pattern :

```nix
{ den, ... }: {
  den.aspects.games = let
    prismlauncher = (den._.user-packages [ "prismlauncher" ]);
    openrct2 = (den._.user-packages [ "openrct2" ]);
    archipelago = (den._.user-packages [ "archipelago" ]);
  in {
    provides = {
      inherit prismlauncher airshipper openrct2 archipelago;
    };
    includes = [
      prismlauncher
      openrct2
      archipelago
    ];
  };
}

# Somewhere else :
#  den.aspects.tux.includes = [
#    <games/prismlauncher> # Only includes prismlauncher.
#    <games/openrct2> # Only includes openrct2.
#  ];
# Or :
#  den.aspects.tux.includes = [
#    <games> # Includes all games.
#  ];
```

Potential improvements/alternative api:

1. Accept either a string or array as input : `den._.user-packages "prismlauncher" # also valid : den._.user-packages [ "prismlauncher" "archipelago" ]`
2. Only accept a string as input : `den._.user-package "prismlauncher"`
3. Add two more batteries for single package : `den._.user-package "prismlauncher" # also valid : den._.user-packages [ "prismlauncher" "archipelago" ]`
4. Somehow figure out a way to merge the functionality of user-packages and system-packages under a single battery : `den._.aspect-with-packages [ "prismlauncher" ] # includes prismlauncher in systemPackages when in host-only context and includes prismlauncher in user packages when in user context`.
5. Include support for unfree packages : `den._.user-packages [ "discord" ] true # includes discord package and allow unfree discord`
6. Include support for packages from non-default source (i.e. nixos-stable and nixos-unstable, no idea how that could work)