### PR TITLE
ci: bump nix-effects to den branch

### DIFF
--- a/nix/lib/aspects/fx/aspect.nix
+++ b/nix/lib/aspects/fx/aspect.nix
@@ -101,7 +101,15 @@ let
           args: rawFn (args // { __scopeKeys = builtins.attrNames scopeHandlers; })
         else
           rawFn;
-      bound = fx.bind.fn (aspect.__args or { }) fn;
+      # nix-effects bind.fn uses lib.functionArgs internally but __args
+      # overrides win via //. Values of true (= has default / optional) must
+      # use the bindAttrs sentinel so the handler probe kicks in; passing
+      # literal true would send it as a param and throw when unhandled.
+      optionalArg = {
+        __bindAttrsOptional = true;
+      };
+      args = lib.mapAttrs (_: v: if v == true then optionalArg else v) (aspect.__args or { });
+      bound = fx.bind.fn args fn;
     in
     if scopeFn != null then scopeFn bound else bound;
 

--- a/templates/ci/flake.lock
+++ b/templates/ci/flake.lock
@@ -101,15 +101,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1777331512,
-        "narHash": "sha256-5x/93lLJLWdR0bHonXT4EXzYRoVbOVto/axHk2ZAeAc=",
+        "lastModified": 1778686186,
+        "narHash": "sha256-oxjrcHFSV2+Rxg4LE4Hupa5HjleTvU1Ir6jp5SburLE=",
         "owner": "denful",
         "repo": "nix-effects",
-        "rev": "8d7e8a97fd1c47ef10c2354b10f2c3f7ac15232c",
+        "rev": "c3c68a45deb892d028711eeff8b80937e30a90dd",
         "type": "github"
       },
       "original": {
         "owner": "denful",
+        "ref": "den",
         "repo": "nix-effects",
         "type": "github"
       }
@@ -184,15 +185,14 @@
         ]
       },
       "locked": {
-        "lastModified": 1,
-        "narHash": "sha256-cTWTT24Up7414XnePBgu30Q6SmQ4OR0zYI4irvZ9g7I=",
         "path": "./provider",
         "type": "path"
       },
       "original": {
         "path": "./provider",
         "type": "path"
-      }
+      },
+      "parent": []
     },
     "root": {
       "inputs": {

--- a/templates/ci/flake.nix
+++ b/templates/ci/flake.nix
@@ -26,7 +26,7 @@
     nix-unit.url = "github:nix-community/nix-unit";
     nix-unit.inputs.nixpkgs.follows = "nixpkgs";
 
-    nix-effects.url = "github:denful/nix-effects";
+    nix-effects.url = "github:denful/nix-effects/den";
     nix-effects.inputs.nixpkgs.follows = "nixpkgs";
     nix-effects.inputs.nix-unit.follows = "nix-unit";
   };


### PR DESCRIPTION
Explicitly using `denful/nix-effects/den` branch instead of the `vic` branch. As part of less-vic is more.