### PR TITLE
fix: disambiguate multi-system homes targeting same homeConfigurations output

### DIFF
--- a/nix/lib/aspects/fx/resolve.nix
+++ b/nix/lib/aspects/fx/resolve.nix
@@ -365,15 +365,62 @@ let
             {
               path = [ "flake" ] ++ spec.intoAttr;
               value = evaluated;
+              system = spec.system or null;
             }
           ]
       ) allInstantiates;
+
+      # Disambiguate instantiate entries targeting the same output path from
+      # different entities. When the same user name appears on multiple systems
+      # (e.g. den.homes.x86_64-linux.ben + den.homes.aarch64-darwin.ben both
+      # producing homeConfigurations.ben), lib.recursiveUpdate would deeply
+      # merge the two independent module-system evaluations, corrupting both.
+      # Fix: qualify each colliding entry's output name with its system so both
+      # are accessible (e.g. homeConfigurations."ben@x86_64-linux").
+      # Same-entity duplicates (e.g. fleet + direct policy) are left as-is
+      # since they produce compatible modules.
+      disambiguatedModules =
+        let
+          pathStr = builtins.concatStringsSep ".";
+          grouped = builtins.foldl' (
+            acc: entry:
+            let
+              key = pathStr entry.path;
+            in
+            acc // { ${key} = (acc.${key} or [ ]) ++ [ entry ]; }
+          ) { } instantiateModules;
+          resolve =
+            _: entries:
+            if builtins.length entries <= 1 then
+              entries
+            else
+              let
+                systems = map (e: e.system or null) entries;
+                uniqueSystems = lib.unique systems;
+                isMultiSystem = builtins.length uniqueSystems > 1;
+              in
+              if isMultiSystem then
+                # Different systems: qualify each output name with @system.
+                map (
+                  e:
+                  let
+                    basePath = lib.init e.path;
+                    baseName = lib.last e.path;
+                  in
+                  e // { path = basePath ++ [ "${baseName}@${e.system}" ]; }
+                ) entries
+              else
+                # Same entity via multiple policy paths: keep last.
+                [ (lib.last entries) ];
+        in
+        lib.concatLists (lib.mapAttrsToList resolve grouped);
+
       # Merge all instantiate outputs into a single module via recursiveUpdate.
-      # This avoids conflicting definitions at intermediate lazyAttrsOf keys
-      # (e.g., multiple instantiates targeting different keys under the same
-      # freeform parent). Leaf values remain lazy — recursiveUpdate only
-      # merges attrset structure, not leaf thunks.
-      instantiateConfigs = map (entry: lib.setAttrByPath entry.path entry.value) instantiateModules;
+      # After disambiguation, each output path appears at most once, so
+      # recursiveUpdate only merges attrset structure across different paths
+      # (e.g., homeConfigurations vs nixosConfigurations), not across
+      # conflicting evaluations of the same entity.
+      instantiateConfigs = map (entry: lib.setAttrByPath entry.path entry.value) disambiguatedModules;
     in
     classImports
     // {

--- a/templates/ci/modules/features/deadbugs/home-intoattr-collision.nix
+++ b/templates/ci/modules/features/deadbugs/home-intoattr-collision.nix
@@ -1,0 +1,77 @@
+# Regression: two den.homes on different systems with the same user name both
+# default intoAttr to ["homeConfigurations" name]. Previously lib.recursiveUpdate
+# silently merged two unrelated module-system evaluations, mixing Linux/Darwin
+# paths and causing stack overflow. Fix: auto-qualify colliding output names
+# with @system so both are accessible.
+{ denTest, ... }:
+{
+  flake.tests.home-intoattr-collision = {
+
+    # Same user on two systems: should produce system-qualified names.
+    test-multi-system-qualified = denTest (
+      { config, den, ... }:
+      {
+        den.homes.x86_64-linux.tux = { };
+        den.homes.aarch64-linux.tux = { };
+        den.default.homeManager.home.stateVersion = "25.11";
+        den.default.includes = [ den.provides.define-user ];
+
+        expr = builtins.sort (a: b: a < b) (builtins.attrNames config.flake.homeConfigurations);
+        expected = [
+          "tux@aarch64-linux"
+          "tux@x86_64-linux"
+        ];
+      }
+    );
+
+    # Each qualified entry should have the correct system's pkgs.
+    test-multi-system-correct-pkgs = denTest (
+      { config, den, ... }:
+      {
+        den.homes.x86_64-linux.tux = { };
+        den.homes.aarch64-linux.tux = { };
+        den.default.homeManager.home.stateVersion = "25.11";
+        den.default.includes = [ den.provides.define-user ];
+
+        expr = config.flake.homeConfigurations."tux@x86_64-linux".config.nixpkgs.system;
+        expected = "x86_64-linux";
+      }
+    );
+
+    # Single system should keep plain name (no qualification needed).
+    test-single-system-plain = denTest (
+      { config, den, ... }:
+      {
+        den.homes.x86_64-linux.tux = { };
+        den.default.homeManager.home.stateVersion = "25.11";
+        den.default.includes = [ den.provides.define-user ];
+
+        expr = builtins.attrNames config.flake.homeConfigurations;
+        expected = [ "tux" ];
+      }
+    );
+
+    # Manual intoAttr override should still work.
+    test-disambiguated-intoattr = denTest (
+      { config, den, ... }:
+      {
+        den.homes.x86_64-linux.tux = { };
+        den.homes.aarch64-linux.tux = {
+          intoAttr = [
+            "homeConfigurations"
+            "tux-aarch64"
+          ];
+        };
+        den.default.homeManager.home.stateVersion = "25.11";
+        den.default.includes = [ den.provides.define-user ];
+
+        expr = builtins.attrNames config.flake.homeConfigurations;
+        expected = [
+          "tux"
+          "tux-aarch64"
+        ];
+      }
+    );
+
+  };
+}


### PR DESCRIPTION
## Summary

- When the same user name is declared under `den.homes` on multiple systems (e.g. `x86_64-linux` + `aarch64-darwin`), both default `intoAttr` to `homeConfigurations.<name>`. Previously `lib.recursiveUpdate` silently merged the two independent module-system evaluations, mixing platform paths (`/home/ben/` + `/Users/ben/`) and causing stack overflow.
- Auto-qualify colliding output names with `@system` so both are accessible: `homeConfigurations."ben@x86_64-linux"` and `homeConfigurations."ben@aarch64-darwin"`.
- Single-system homes keep the plain name. Same-entity duplicates from multiple policy paths (e.g. fleet + direct) are deduped to last entry.

## Test plan

- [x] 829/829 CI tests pass (4 new)
- [x] `pipe-scope.test-pipe-collect-fleet` passes (same-entity via fleet + direct policy not broken)
- [x] Verified against `benbelov-nixconfig` — produces `ben@x86_64-linux` and `ben@aarch64-darwin` with correct system pkgs each