### PR TITLE
fix: stop routing OS users into custom host classes

### DIFF
--- a/modules/aspects/batteries/os-user.nix
+++ b/modules/aspects/batteries/os-user.nix
@@ -33,7 +33,7 @@ in
 {
   den.classes.user.description = "Lightweight user environment forwarding to OS users.users";
 
-  # Built-in policy: route user class content to the host's OS at
+  # Built-in policy: route user class content to NixOS/nix-Darwin at
   # users.users.<userName>. Injects osConfig so user-class modules
   # can reference the parent NixOS/Darwin config.
   # The route's ensureEntry mechanism creates users.users.<name> even
@@ -41,17 +41,27 @@ in
   den.default.includes = [ den.policies.user-to-host ];
 
   den.policies.user-to-host =
-    { user, host, ... }:
-    [
-      (den.lib.policy.route {
-        fromClass = "user";
-        intoClass = host.class;
-        path = [
-          "users"
-          "users"
-          user.userName
-        ];
-        adaptArgs = args: args // { osConfig = args.config; };
-      })
-    ];
+    den.lib.policy.when
+      (
+        { user, host, ... }:
+        builtins.elem host.class [
+          "nixos"
+          "darwin"
+        ]
+      )
+      (
+        { user, host, ... }:
+        [
+          (den.lib.policy.route {
+            fromClass = "user";
+            intoClass = host.class;
+            path = [
+              "users"
+              "users"
+              user.userName
+            ];
+            adaptArgs = args: args // { osConfig = args.config; };
+          })
+        ]
+      );
 }

--- a/templates/ci/modules/features/os-user-class.nix
+++ b/templates/ci/modules/features/os-user-class.nix
@@ -14,6 +14,47 @@
       }
     );
 
+    test-does-not-forward-user-description-to-custom-host = denTest (
+      {
+        config,
+        den,
+        lib,
+        ...
+      }:
+      let
+        mockCustomHostModule =
+          { lib, ... }:
+          {
+            config._module.freeformType = lib.types.lazyAttrsOf lib.types.unspecified;
+          };
+
+        igloo-custom-host = config.flake.iglooCustomHostConfigurations."igloo-custom-host";
+      in
+      {
+        den.classes.custom-host.description = "Custom host configuration";
+
+        den.hosts.x86_64-linux.igloo-custom-host = {
+          class = "custom-host";
+          intoAttr = [
+            "iglooCustomHostConfigurations"
+            "igloo-custom-host"
+          ];
+          instantiate =
+            { modules, ... }:
+            (lib.evalModules {
+              modules = [ mockCustomHostModule ] ++ modules;
+            }).config;
+        };
+
+        den.hosts.x86_64-linux.igloo-custom-host.users.tux = { };
+
+        den.aspects.tux.user.description = "pinguino";
+
+        expr = igloo-custom-host.users.users.tux.description or null;
+        expected = null;
+      }
+    );
+
     test-forwards-os-args = denTest (
       {
         den,
@@ -110,5 +151,6 @@
         expected = [ "wheel" ];
       }
     );
+
   };
 }


### PR DESCRIPTION
## Bug
`den.batteries.os-user` is documented as forwarding the `user` class into OS-level `users.users.<name>` on NixOS/nix-Darwin hosts. However, the policy actually routes unconditionally into `host.class`, so custom host classes receive a `users.users.<name>` entry, even when no OS user module exists there.

## Changes
- Guard `den.policies.user-to-host` so it only emits routes for `host.class == "nixos"` or `"darwin"`.
- Add a regression test covering the custom host class case

## AI Assistance
Codex with GPT-5.5 xhigh was used to identify the issue, prepare this patch, draft the commit message, and draft this PR description. The work was guided, reviewed, and accepted by myself.

I, Scott Guest, explicitly acknowledge the following:
- [x] My contribution is AI generated and I mention which models/mcp-servers/tools were used.
- [x] I recognize AI generated contribution as my own and am myself legally accountable for it.
- [x] My contribution aligns with Den LICENSE and does not violate any other projects licenses (e.g. GPL)
- [x] I will truthfully answer and provide any requested details on how contribution was generated.