### PR TITLE
fix: route wrapping merge semantics and forward ordering

### DIFF
--- a/nix/lib/aspects/fx/resolve.nix
+++ b/nix/lib/aspects/fx/resolve.nix
@@ -410,8 +410,16 @@ let
                   e // { path = basePath ++ [ "${baseName}@${e.system}" ]; }
                 ) entries
               else
-                # Same entity via multiple policy paths: keep last.
-                [ (lib.last entries) ];
+                # Same entity via multiple policy paths: deduplicate.
+                # Warn when more than one distinct instantiate spec targets the
+                # same output path on the same system — this can silently shadow
+                # one entity's configuration with another's.
+                let
+                  entry = lib.last entries;
+                in
+                lib.warnIf (builtins.length entries > 1)
+                  "den: multiple instantiate specs target ${builtins.concatStringsSep "." entry.path} on ${entry.system or "unknown"}; keeping last"
+                  [ entry ];
         in
         lib.concatLists (lib.mapAttrsToList resolve grouped);
 

--- a/nix/lib/aspects/fx/route/apply.nix
+++ b/nix/lib/aspects/fx/route/apply.nix
@@ -241,6 +241,37 @@ let
     in
     go { } rawRoutes;
 
+  # Topologically sort routes: when forward A's intoClass feeds forward
+  # B's fromClass at the same scope, A must fire before B.  Only
+  # reorders __complexForward routes; non-forward routes keep their
+  # original position relative to other non-forwards.  (#567)
+  topoSortRoutes =
+    routes:
+    let
+      indexed = lib.imap0 (i: r: { inherit i r; }) routes;
+      # Build producer map: intoClass@scope → [route indices]
+      producerMap = builtins.foldl' (
+        acc:
+        { i, r }:
+        if r.__complexForward or false then
+          let
+            key = "${r.intoClass}@${r.sourceScopeId}";
+          in
+          acc // { ${key} = (acc.${key} or [ ]) ++ [ i ]; }
+        else
+          acc
+      ) { } indexed;
+      # A complex forward is "depends on producers" when its fromClass@scope
+      # has entries in producerMap (meaning another forward produces into it).
+      hasDeps =
+        { i, r }: (r.__complexForward or false) && producerMap ? "${r.fromClass}@${r.sourceScopeId}";
+      # Partition: routes without deps first, routes with deps last.
+      # This is a single-level toposort (sufficient for A→B chains).
+      noDeps = builtins.filter (ir: !hasDeps ir) indexed;
+      withDeps = builtins.filter hasDeps indexed;
+    in
+    map (ir: ir.r) (noDeps ++ withDeps);
+
   # Main entry: dedup routes, fold applying each.
   applyRoutes =
     {
@@ -255,7 +286,9 @@ let
       buildForwardAspect ? null,
     }:
     let
-      allRoutes = dedupRoutes rootScopeId (lib.concatLists (lib.attrValues scopedRoutes));
+      allRoutes = topoSortRoutes (
+        dedupRoutes rootScopeId (lib.concatLists (lib.attrValues scopedRoutes))
+      );
     in
     builtins.foldl'
       (

--- a/nix/lib/aspects/fx/route/wrap.nix
+++ b/nix/lib/aspects/fx/route/wrap.nix
@@ -79,6 +79,11 @@ let
       };
 
   # Apply the adapt → nest → guard pipeline to a list of modules.
+  # When adaptArgs is non-null (nestWithAdaptArgs path), all modules are
+  # combined into a single evalModules call so that multiple aspects
+  # emitting to the same class merge correctly inside evalModules,
+  # rather than producing separate config definitions that get
+  # shallow-merged by the freeform `unspecified` type.  (#572)
   wrapRouteModules =
     {
       modules,
@@ -86,7 +91,15 @@ let
       guard ? null,
       adaptArgs ? null,
     }:
-    map (mod: guardModule guard (nestModule path adaptArgs (adaptModule adaptArgs path mod))) modules;
+    let
+      adapted = map (adaptModule adaptArgs path) modules;
+    in
+    if adapted == [ ] then
+      [ ]
+    else if adaptArgs != null && path != [ ] then
+      [ (guardModule guard (nestWithAdaptArgs path adaptArgs { imports = adapted; })) ]
+    else
+      map (mod: guardModule guard (nestModule path adaptArgs mod)) adapted;
 
   # Collect class modules from a forward aspect (recursing into includes).
   collectClassMods =

--- a/nix/lib/aspects/fx/route/wrap.nix
+++ b/nix/lib/aspects/fx/route/wrap.nix
@@ -1,6 +1,32 @@
 # Route module wrapping — path nesting, guards, adaptArgs.
 { lib, ... }:
 let
+  # Freeform type for route nesting evalModules: merges like NixOS
+  # (attrsets deep-merge, lists concatenate) but errors on conflicting
+  # scalar or derivation values instead of silently clobbering.
+  mergeableType = lib.mkOptionType {
+    name = "mergeable";
+    description = "auto-merged value (attrsets merge, lists concatenate, scalars conflict)";
+    merge =
+      loc: defs:
+      let
+        values = map (d: d.value) defs;
+        first = builtins.head values;
+        allLists = builtins.all builtins.isList values;
+        # Derivations are attrsets but must not deep-merge — treat as opaque.
+        allMergeableAttrs = builtins.all (v: builtins.isAttrs v && !(lib.isDerivation v)) values;
+      in
+      if builtins.length defs == 1 then
+        first
+      else if allLists then
+        builtins.concatLists values
+      else if allMergeableAttrs then
+        (lib.types.lazyAttrsOf mergeableType).merge loc defs
+      else
+        throw "den: the option `${lib.showOption loc}' has conflicting definitions from multiple aspects";
+  };
+  nestingFreeformType = lib.types.lazyAttrsOf mergeableType;
+
   # Adapt a module's args when path is empty (top-level adaptArgs).
   adaptModule =
     adaptArgs: path: mod:
@@ -21,7 +47,7 @@ let
       evaluated = lib.evalModules {
         specialArgs = adapted;
         modules = [
-          { config._module.freeformType = lib.types.lazyAttrsOf lib.types.raw; }
+          { config._module.freeformType = nestingFreeformType; }
         ]
         ++ sourceModules;
       };
@@ -49,7 +75,7 @@ let
       evaluated = lib.evalModules {
         specialArgs = fullArgs;
         modules = [
-          { config._module.freeformType = lib.types.lazyAttrsOf lib.types.raw; }
+          { config._module.freeformType = nestingFreeformType; }
         ]
         ++ resolved;
       };

--- a/nix/lib/aspects/fx/route/wrap.nix
+++ b/nix/lib/aspects/fx/route/wrap.nix
@@ -21,7 +21,7 @@ let
       evaluated = lib.evalModules {
         specialArgs = adapted;
         modules = [
-          { config._module.freeformType = lib.types.lazyAttrsOf lib.types.unspecified; }
+          { config._module.freeformType = lib.types.lazyAttrsOf lib.types.raw; }
         ]
         ++ sourceModules;
       };
@@ -36,22 +36,32 @@ let
       );
     };
 
-  # Nest a module at a path by resolving imports with full outer args.
+  # Nest a module at a path by evaluating imports with full outer args.
+  # Uses evalModules with raw freeform type so conflicting keys error
+  # instead of silently clobbering via recursiveUpdate.
   nestPlain =
     path: mod: args:
     let
       fullArgs = args // (args.config._module.args or { });
       resolveImport = imp: if builtins.isFunction imp then imp fullArgs else imp;
-      resolvedMod =
-        if builtins.isAttrs mod && mod ? imports then
-          lib.foldl' lib.recursiveUpdate { } (map resolveImport mod.imports)
-        else if builtins.isFunction mod then
-          mod fullArgs
-        else
-          mod;
+      sourceModules = if builtins.isAttrs mod && mod ? imports then mod.imports else [ mod ];
+      resolved = map resolveImport sourceModules;
+      evaluated = lib.evalModules {
+        specialArgs = fullArgs;
+        modules = [
+          { config._module.freeformType = lib.types.lazyAttrsOf lib.types.raw; }
+        ]
+        ++ resolved;
+      };
     in
     {
-      config = lib.setAttrByPath path resolvedMod;
+      config = lib.setAttrByPath path (
+        builtins.removeAttrs evaluated.config [
+          "_module"
+          "warnings"
+          "assertions"
+        ]
+      );
     };
 
   # Nest a module at a target path (dispatch between adapt and plain strategies).

--- a/templates/ci/modules/features/forward-each-mutual.nix
+++ b/templates/ci/modules/features/forward-each-mutual.nix
@@ -1,0 +1,52 @@
+# Regression test for #567: class forwarder with `each` breaks when
+# imported from mutual provider aspect.
+{ denTest, ... }:
+{
+  flake.tests.forward-each-mutual = {
+
+    test-forward-each-from-provide = denTest (
+      {
+        den,
+        lib,
+        igloo,
+        tuxHm,
+        ...
+      }:
+      let
+        nixClass =
+          { class, aspect-chain, ... }:
+          den._.forward {
+            each = [
+              "nixos"
+              "homeManager"
+            ];
+            fromClass = _: "nix";
+            intoClass = lib.id;
+            intoPath = _: [ "nix" ];
+            fromAspect = _: lib.head aspect-chain;
+            adaptArgs = lib.id;
+          };
+      in
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.default.includes = [ den._.mutual-provider ];
+
+        den.aspects.tux.provides.igloo = {
+          includes = [ nixClass ];
+          nix.settings.experimental-features = "flakes";
+        };
+
+        expr = {
+          nixos = igloo.nix.settings.experimental-features;
+          hm = tuxHm.nix.settings.experimental-features;
+        };
+        expected = {
+          nixos = "flakes";
+          hm = "flakes";
+        };
+      }
+    );
+
+  };
+}

--- a/templates/ci/modules/features/packages-merge.nix
+++ b/templates/ci/modules/features/packages-merge.nix
@@ -80,9 +80,8 @@
       }
     );
 
-    # Overlapping key: last included aspect wins for same package name
-    # (evalModules freeform merge with unspecified type).
-    test-overlapping-key-last-wins = denTest (
+    # Overlapping key: two aspects defining the same package name errors.
+    test-overlapping-key-errors = denTest (
       {
         config,
         den,
@@ -110,9 +109,11 @@
           den.aspects.pkg-v2
         ];
 
-        # Both define "shared" — last included wins within the combined evalModules.
         expr = builtins.attrNames config.flake.packages.x86_64-linux;
-        expected = [ "shared" ];
+        expectedError = {
+          type = "ThrownError";
+          msg = "The option `shared' has conflicting definition values";
+        };
       }
     );
 

--- a/templates/ci/modules/features/packages-merge.nix
+++ b/templates/ci/modules/features/packages-merge.nix
@@ -1,0 +1,120 @@
+# Regression test for #572: multiple aspects defining `packages` should merge,
+# not clobber (last-write-wins).
+{ denTest, inputs, ... }:
+{
+  imports = [ inputs.den.flakeOutputs.packages ];
+
+  flake.tests.packages-merge = {
+
+    # Two aspects each defining a different package should both appear.
+    test-multi-aspect-packages = denTest (
+      {
+        config,
+        den,
+        ...
+      }:
+      {
+        imports = [ inputs.den.flakeOutputs.packages ];
+
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.pkg-one.packages =
+          { pkgs, ... }:
+          {
+            one = pkgs.writeText "one" "1";
+          };
+
+        den.aspects.pkg-two.packages =
+          { pkgs, ... }:
+          {
+            two = pkgs.writeText "two" "2";
+          };
+
+        den.schema.flake-system.includes = [
+          den.aspects.pkg-one
+          den.aspects.pkg-two
+        ];
+
+        expr = builtins.sort (a: b: a < b) (builtins.attrNames config.flake.packages.x86_64-linux);
+        expected = [
+          "one"
+          "two"
+        ];
+      }
+    );
+
+    # Same scenario using den.default includes.
+    test-multi-aspect-packages-via-default = denTest (
+      {
+        config,
+        den,
+        ...
+      }:
+      {
+        imports = [ inputs.den.flakeOutputs.packages ];
+
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.default.includes = [
+          den.aspects.pkg-alpha
+          den.aspects.pkg-beta
+        ];
+
+        den.aspects.pkg-alpha.packages =
+          { pkgs, ... }:
+          {
+            alpha = pkgs.writeText "alpha" "a";
+          };
+
+        den.aspects.pkg-beta.packages =
+          { pkgs, ... }:
+          {
+            beta = pkgs.writeText "beta" "b";
+          };
+
+        expr = builtins.sort (a: b: a < b) (builtins.attrNames config.flake.packages.x86_64-linux);
+        expected = [
+          "alpha"
+          "beta"
+        ];
+      }
+    );
+
+    # Overlapping key: last included aspect wins for same package name
+    # (evalModules freeform merge with unspecified type).
+    test-overlapping-key-last-wins = denTest (
+      {
+        config,
+        den,
+        ...
+      }:
+      {
+        imports = [ inputs.den.flakeOutputs.packages ];
+
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.pkg-v1.packages =
+          { pkgs, ... }:
+          {
+            shared = pkgs.writeText "shared" "v1";
+          };
+
+        den.aspects.pkg-v2.packages =
+          { pkgs, ... }:
+          {
+            shared = pkgs.writeText "shared" "v2";
+          };
+
+        den.schema.flake-system.includes = [
+          den.aspects.pkg-v1
+          den.aspects.pkg-v2
+        ];
+
+        # Both define "shared" — last included wins within the combined evalModules.
+        expr = builtins.attrNames config.flake.packages.x86_64-linux;
+        expected = [ "shared" ];
+      }
+    );
+
+  };
+}

--- a/templates/ci/modules/features/packages-merge.nix
+++ b/templates/ci/modules/features/packages-merge.nix
@@ -109,10 +109,11 @@
           den.aspects.pkg-v2
         ];
 
-        expr = builtins.attrNames config.flake.packages.x86_64-linux;
+        # Force evaluation of the conflicting value — attrNames alone is lazy.
+        expr = config.flake.packages.x86_64-linux.shared.name;
         expectedError = {
           type = "ThrownError";
-          msg = "The option `shared' has conflicting definition values";
+          msg = "den: the option `shared' has conflicting definitions from multiple aspects";
         };
       }
     );


### PR DESCRIPTION
Closes #572, closes #567

## Summary

Three route application fixes in the fx pipeline:

**#572 — Multiple aspects defining the same flake output class clobber each other.** `wrapRouteModules` evaluated each source module independently through `nestWithAdaptArgs`, producing separate config definitions. The flake submodule's freeform `unspecified` type shallow-merged them with `//`, keeping only the last.

**#567 — Class forwarder with `each` breaks when imported from a mutual provider.** Forward routes like `nix→homeManager` registered after the HM battery route `homeManager→nixos`. The consumer fired first and collected from `homeManager` before the producer had written to it.

**Audit — `nestPlain` had the same shallow merge, freeform type was too permissive, and duplicate instantiate specs were silently dropped.**

## Changes

- **`route/wrap.nix`**: Combine all source modules into a single `evalModules` call for the `nestWithAdaptArgs` path. Align `nestPlain` to also use `evalModules` instead of `recursiveUpdate`. Introduce `mergeableType` — a custom freeform type that deep-merges attrsets, concatenates lists, and errors on conflicting scalar/derivation values (matching NixOS module system semantics).
- **`route/apply.nix`**: Add `topoSortRoutes` — partitions complex forward routes so producers (whose `intoClass` feeds another forward's `fromClass`) fire before consumers.
- **`resolve.nix`**: Add `lib.warnIf` when multiple instantiate specs target the same output path on the same system.
- **Regression tests**: 4 new tests across 2 files.

## Test plan

- [x] 833/833 CI tests pass
- [x] `flake-parts-modules` template passes (previously failed with `raw` freeform type)
- [x] All other templates pass `just check-all` (same results as main)
- [x] Formatting clean