### PR TITLE
fix: null coercion in disambiguate warning message

### DIFF
--- a/nix/lib/aspects/fx/resolve.nix
+++ b/nix/lib/aspects/fx/resolve.nix
@@ -418,7 +418,9 @@ let
                   entry = lib.last entries;
                 in
                 lib.warnIf (builtins.length entries > 1)
-                  "den: multiple instantiate specs target ${builtins.concatStringsSep "." entry.path} on ${entry.system or "unknown"}; keeping last"
+                  "den: multiple instantiate specs target ${builtins.concatStringsSep "." entry.path} on ${
+                    if entry.system != null then entry.system else "unknown"
+                  }; keeping last"
                   [ entry ];
         in
         lib.concatLists (lib.mapAttrsToList resolve grouped);


### PR DESCRIPTION
## Summary
- `entry.system or "unknown"` in the disambiguation warning throws `cannot coerce null to a string` when `entry.system` is `null`
- Nix's `or` only applies to attribute access (`a.b or default`), not standalone values
- Use explicit `if` check instead

Introduced in #565 (`0b250e17`).

## Test plan
- [ ] `nix flake check` passes
- [ ] Flake with duplicate instantiate specs on null-system entities no longer crashes