### PR TITLE
perf: break closure chains and lazy instantiation backport

### DIFF
--- a/nix/lib/aspects/fx/assemble-pipes.nix
+++ b/nix/lib/aspects/fx/assemble-pipes.nix
@@ -39,17 +39,29 @@ let
   # These are quirk values like `{ host, ... }: { addr = host.addr; }` that
   # require pipeline context (host, user, etc.) but not NixOS config.
   # Without this, the raw function would be passed to consumers as-is.
+  # If required args (non-optional, not `lib`) are missing from scope context,
+  # the value is passed through unresolved — the consumer is responsible for
+  # providing the missing args (e.g., perSystem CRD build pipeline provides pkgs).
   resolveLocalParametric =
     scopeCtx: val:
     if isPipelineParametric val then
       let
         thunkArgs = builtins.functionArgs val;
-        ctxArgs = lib.genAttrs (builtins.filter (k: scopeCtx ? ${k}) (builtins.attrNames thunkArgs)) (
-          k: scopeCtx.${k}
+        requiredArgs = builtins.filter (k: !(thunkArgs.${k} or false) && k != "lib") (
+          builtins.attrNames thunkArgs
         );
-        result = val (ctxArgs // { inherit lib; });
+        allSatisfied = builtins.all (k: scopeCtx ? ${k}) requiredArgs;
       in
-      if builtins.isList result then result else [ result ]
+      if !allSatisfied then
+        [ val ]
+      else
+        let
+          ctxArgs = lib.genAttrs (builtins.filter (k: scopeCtx ? ${k}) (builtins.attrNames thunkArgs)) (
+            k: scopeCtx.${k}
+          );
+          result = val (ctxArgs // { inherit lib; });
+        in
+        if builtins.isList result then result else [ result ]
     else
       [ val ];
 
@@ -190,6 +202,64 @@ let
     in
     builtins.filter predicateMatches siblings;
 
+  # Find all scopes matching a predicate, regardless of parent.
+  findMatchingAll =
+    {
+      scopeContexts,
+      scopeEntityKind ? { },
+      currentScopeId,
+    }:
+    predicate:
+    let
+      entityKinds = den.lib.schemaUtil.schemaEntityKinds;
+      allScopeIds = builtins.attrNames scopeContexts;
+      candidates = builtins.filter (sid: sid != currentScopeId) allScopeIds;
+      predArgs = builtins.functionArgs predicate;
+      requiredArgs = builtins.filter (k: !predArgs.${k}) (builtins.attrNames predArgs);
+      predEntityArgs = builtins.filter (k: builtins.elem k entityKinds) requiredArgs;
+      predicateMatches =
+        sid:
+        let
+          ctx = scopeContexts.${sid};
+          hasRequired = builtins.all (k: ctx ? ${k}) requiredArgs;
+          ownKind = scopeEntityKind.${sid} or null;
+          scopeOwnEntityKinds =
+            if ownKind != null then [ ownKind ] else builtins.filter (k: ctx ? ${k}) entityKinds;
+          extraEntityKinds = builtins.filter (k: !builtins.elem k predEntityArgs) scopeOwnEntityKinds;
+        in
+        hasRequired && extraEntityKinds == [ ] && predicate ctx;
+    in
+    builtins.filter predicateMatches candidates;
+
+  # Collect quirks from all scopes matching a predicate (no parent constraint).
+  collectFromAll =
+    {
+      scopeContexts,
+      scopeEntityKind ? { },
+      scopedClassImports,
+      currentScopeId,
+      pipeName,
+      hostConfigs ? null,
+    }:
+    predicate:
+    let
+      matchingScopes = findMatchingAll {
+        inherit
+          scopeContexts
+          scopeEntityKind
+          currentScopeId
+          ;
+      } predicate;
+    in
+    lib.concatMap (
+      sid:
+      let
+        entries = (scopedClassImports.${sid} or { }).${pipeName} or [ ];
+        values = flattenAndExtract entries;
+      in
+      resolveThunks hostConfigs scopeContexts sid values
+    ) matchingScopes;
+
   # Collect quirks from sibling scopes matching a predicate.
   collectFromPeers =
     {
@@ -247,6 +317,7 @@ let
           "append"
           "for"
           "collect"
+          "collectAll"
           "withProvenance"
         ]
       ) stages;
@@ -295,6 +366,42 @@ let
             inherit
               scopeContexts
               scopeParent
+              scopeEntityKind
+              scopedClassImports
+              currentScopeId
+              pipeName
+              hostConfigs
+              ;
+          } stage.fn
+      else if t == "collectAll" then
+        if hasProvenance then
+          let
+            matchingScopes = findMatchingAll {
+              inherit
+                scopeContexts
+                scopeEntityKind
+                currentScopeId
+                ;
+            } stage.fn;
+            collected = lib.concatMap (
+              sid:
+              let
+                entries = (scopedClassImports.${sid} or { }).${pipeName} or [ ];
+                rawValues = flattenAndExtract entries;
+                resolved = resolveThunks hostConfigs scopeContexts sid rawValues;
+              in
+              map (v: {
+                __pv = v;
+                __ps = sid;
+              }) resolved
+            ) matchingScopes;
+          in
+          values ++ collected
+        else
+          values
+          ++ collectFromAll {
+            inherit
+              scopeContexts
               scopeEntityKind
               scopedClassImports
               currentScopeId
@@ -393,6 +500,7 @@ let
         s:
         builtins.elem (s.__pipeStage or "") [
           "collect"
+          "collectAll"
           "withProvenance"
         ]
       ) stages

--- a/nix/lib/aspects/fx/handlers/chain.nix
+++ b/nix/lib/aspects/fx/handlers/chain.nix
@@ -13,23 +13,21 @@ let
       };
     "chain-pop" =
       { param, state }:
+      let
+        all = state.scopedIncludesChain null;
+        scopeChain = all.${state.currentScope} or [ ];
+        updated = all // {
+          ${state.currentScope} =
+            if scopeChain == [ ] then
+              throw "fx: chain-pop on empty scopedIncludesChain"
+            else
+              lib.init scopeChain;
+        };
+      in
       {
         resume = null;
         state = state // {
-          scopedIncludesChain =
-            _:
-            let
-              all = state.scopedIncludesChain null;
-              scopeChain = all.${state.currentScope} or [ ];
-            in
-            all
-            // {
-              ${state.currentScope} =
-                if scopeChain == [ ] then
-                  throw "fx: chain-pop on empty scopedIncludesChain"
-                else
-                  lib.init scopeChain;
-            };
+          scopedIncludesChain = _: updated;
         };
       };
   };

--- a/nix/lib/aspects/fx/handlers/class-collector.nix
+++ b/nix/lib/aspects/fx/handlers/class-collector.nix
@@ -36,20 +36,18 @@ let
           if alreadyEmitted then
             state
           else
+            let
+              allImports = state.scopedClassImports null;
+              scopeImportData = allImports.${scope} or { };
+              updatedImports = allImports // {
+                ${scope} = scopeImportData // {
+                  ${param.class} = (scopeImportData.${param.class} or [ ]) ++ [ mod ];
+                };
+              };
+            in
             state
             // {
-              scopedClassImports =
-                x:
-                let
-                  all = state.scopedClassImports x;
-                  scopeData = all.${scope} or { };
-                in
-                all
-                // {
-                  ${scope} = scopeData // {
-                    ${param.class} = (scopeData.${param.class} or [ ]) ++ [ mod ];
-                  };
-                };
+              scopedClassImports = _: updatedImports;
               scopedEmittedLocs =
                 _:
                 emittedLocs

--- a/nix/lib/aspects/fx/handlers/constraint.nix
+++ b/nix/lib/aspects/fx/handlers/constraint.nix
@@ -85,24 +85,17 @@ let
         {
           resume = null;
           state =
-            (
-              state
-              // {
-                scopedConstraintRegistry =
-                  _:
-                  let
-                    all = (state.scopedConstraintRegistry or (_: { })) null;
-                    inherit (state) currentScope;
-                    scopeData = all.${currentScope} or { };
-                  in
-                  all
-                  // {
-                    ${currentScope} = scopeData // {
-                      ${param.identity} = (scopeData.${param.identity} or [ ]) ++ [ entry ];
-                    };
-                  };
-              }
-            )
+            let
+              all = (state.scopedConstraintRegistry or (_: { })) null;
+              inherit (state) currentScope;
+              scopeData = all.${currentScope} or { };
+              updatedRegistry = all // {
+                ${currentScope} = scopeData // {
+                  ${param.identity} = (scopeData.${param.identity} or [ ]) ++ [ entry ];
+                };
+              };
+            in
+            (state // { scopedConstraintRegistry = _: updatedRegistry; })
             // {
               flatConstraintRegistry = flatReg // {
                 ${param.identity} = existing ++ [ entry ];

--- a/nix/lib/aspects/fx/handlers/push-scope.nix
+++ b/nix/lib/aspects/fx/handlers/push-scope.nix
@@ -25,6 +25,28 @@ let
         allDeferred = (state.scopedDeferredIncludes or (_: { })) null;
         parentItems = allDeferred.${parentScope} or [ ];
       in
+      let
+        prevContexts = state.scopeContexts null;
+        prevParent = state.scopeParent null;
+        prevPolicies = state.scopedAspectPolicies null;
+        prevEntityClass = (state.scopeEntityClass or (_: { })) null;
+        prevEntityKind = (state.scopeEntityKind or (_: { })) null;
+        prevSourcePolicy = (state.scopeSourcePolicy or (_: { })) null;
+        updatedContexts = prevContexts // {
+          ${newScopeId} = scopedCtx;
+        };
+        updatedParent = prevParent // lib.optionalAttrs (!isSameScope) { ${newScopeId} = parentScope; };
+        updatedPolicies = prevPolicies // {
+          ${newScopeId} = prevPolicies.${newScopeId} or { };
+        };
+        updatedEntityClass =
+          prevEntityClass // lib.optionalAttrs (entityClass != null) { ${newScopeId} = entityClass; };
+        updatedEntityKind =
+          prevEntityKind // lib.optionalAttrs (entityKind != null) { ${newScopeId} = entityKind; };
+        updatedSourcePolicy =
+          prevSourcePolicy
+          // lib.optionalAttrs (sourcePolicyName != null) { ${newScopeId} = sourcePolicyName; };
+      in
       {
         resume = {
           inherit scopeHandlers;
@@ -34,53 +56,14 @@ let
           state
           // {
             currentScope = newScopeId;
-            # Save and reset inLateDispatch — each scope level gets its own
-            # late-dispatch opportunity.  restore-scope pops the saved value.
             inLateDispatch = false;
             inLateDispatchStack = (state.inLateDispatchStack or [ ]) ++ [ (state.inLateDispatch or false) ];
-            scopeContexts =
-              _:
-              (state.scopeContexts null)
-              // {
-                ${newScopeId} = scopedCtx;
-              };
-            scopeParent =
-              _: (state.scopeParent null) // lib.optionalAttrs (!isSameScope) { ${newScopeId} = parentScope; };
-            # No parent inheritance — policies fire where registered, not at
-            # child scopes.  Cascade is through effects, not re-dispatch.
-            scopedAspectPolicies =
-              _:
-              let
-                all = state.scopedAspectPolicies null;
-              in
-              all // { ${newScopeId} = all.${newScopeId} or { }; };
-            # Record source policy name — installPolicies reads this to
-            # exclude the source policy from dispatch at this scope.
-            # Invariant: policies don't apply to their own outputs.
-            # Track entity class per scope — separate from scopeContexts to avoid
-            # affecting provides/enrichment.  Read by bind's state fallback and
-            # subtree extraction.
-            scopeEntityClass =
-              _:
-              ((state.scopeEntityClass or (_: { })) null)
-              // lib.optionalAttrs (entityClass != null) {
-                ${newScopeId} = entityClass;
-              };
-            # Track which entity kind each scope was created for.
-            # Used by collectFromPeers to filter by the scope's own entity kind
-            # rather than all entity kinds inherited from parent context.
-            scopeEntityKind =
-              _:
-              ((state.scopeEntityKind or (_: { })) null)
-              // lib.optionalAttrs (entityKind != null) {
-                ${newScopeId} = entityKind;
-              };
-            scopeSourcePolicy =
-              _:
-              ((state.scopeSourcePolicy or (_: { })) null)
-              // lib.optionalAttrs (sourcePolicyName != null) {
-                ${newScopeId} = sourcePolicyName;
-              };
+            scopeContexts = _: updatedContexts;
+            scopeParent = _: updatedParent;
+            scopedAspectPolicies = _: updatedPolicies;
+            scopeEntityClass = _: updatedEntityClass;
+            scopeEntityKind = _: updatedEntityKind;
+            scopeSourcePolicy = _: updatedSourcePolicy;
           }
           // lib.optionalAttrs (parentItems != [ ]) {
             scopedDeferredIncludes =

--- a/nix/lib/aspects/fx/handlers/state-util.nix
+++ b/nix/lib/aspects/fx/handlers/state-util.nix
@@ -1,41 +1,42 @@
 # Shared state mutation helpers for scoped pipeline fields.
+#
+# Each field is stored as a thunk `_: attrset` so that nix-effects'
+# deepSeq on state doesn't force all fields eagerly.  However, we
+# must prevent closure *chains*: if each write wraps the previous
+# thunk, reading the final value costs O(N) and N reads costs O(N²).
+# Fix: materialise the previous value outside the thunk closure via let
+# binding, so each read is O(1).
 {
   # Append an item to a scoped list field.
   scopedAppend =
     state: field: scope: item:
-    state
-    // {
-      ${field} =
-        _:
-        let
-          all = (state.${field} or (_: { })) null;
-        in
-        all // { ${scope} = (all.${scope} or [ ]) ++ [ item ]; };
-    };
+    let
+      all = (state.${field} or (_: { })) null;
+      updated = all // {
+        ${scope} = (all.${scope} or [ ]) ++ [ item ];
+      };
+    in
+    state // { ${field} = _: updated; };
 
   # Append multiple items to a scoped list field.
   scopedAppendMany =
     state: field: scope: items:
-    state
-    // {
-      ${field} =
-        _:
-        let
-          all = (state.${field} or (_: { })) null;
-        in
-        all // { ${scope} = (all.${scope} or [ ]) ++ items; };
-    };
+    let
+      all = (state.${field} or (_: { })) null;
+      updated = all // {
+        ${scope} = (all.${scope} or [ ]) ++ items;
+      };
+    in
+    state // { ${field} = _: updated; };
 
   # Merge attrs into a scoped attrset field.
   scopedMerge =
     state: field: scope: attrs:
-    state
-    // {
-      ${field} =
-        _:
-        let
-          all = (state.${field} or (_: { })) null;
-        in
-        all // { ${scope} = (all.${scope} or { }) // attrs; };
-    };
+    let
+      all = (state.${field} or (_: { })) null;
+      updated = all // {
+        ${scope} = (all.${scope} or { }) // attrs;
+      };
+    in
+    state // { ${field} = _: updated; };
 }

--- a/nix/lib/aspects/fx/handlers/widen-context.nix
+++ b/nix/lib/aspects/fx/handlers/widen-context.nix
@@ -8,10 +8,15 @@ _: {
       let
         enrichedCtx = param.currentCtx // param.enrichment;
       in
+      let
+        updated = (state.scopeContexts null) // {
+          ${state.currentScope} = enrichedCtx;
+        };
+      in
       {
         resume = null;
         state = state // {
-          scopeContexts = _: (state.scopeContexts null) // { ${state.currentScope} = enrichedCtx; };
+          scopeContexts = _: updated;
         };
       };
   };

--- a/nix/lib/aspects/fx/resolve.nix
+++ b/nix/lib/aspects/fx/resolve.nix
@@ -249,15 +249,107 @@ let
     in
     if deduped == [ ] then null else deduped;
 
+  # Build instantiateArgs for a spec without calling spec.instantiate.
+  # Factored out so both applyInstantiates and hostConfigs can reuse it.
+  mkInstantiateArgs =
+    {
+      augmentedScopeContexts,
+      scopedClassImportsRaw,
+      scopedProvides,
+      scopedRoutes,
+      scopeParent,
+      scopeEntityClass ? (_: { }),
+      fxResolveFn,
+      ctx,
+    }:
+    spec:
+    let
+      allScopeIds = builtins.attrNames augmentedScopeContexts;
+      hostClass = spec.class or "nixos";
+      rawHostScopeId = findHostScopeId scopeParent allScopeIds spec;
+      hostScopeId = if rawHostScopeId != null then rawHostScopeId else spec.sourceScopeId;
+      preWalkedModules =
+        if hostScopeId != null then
+          let
+            isInSubtree =
+              sid:
+              sid == hostScopeId
+              || (
+                let
+                  parent = scopeParent.${sid} or null;
+                in
+                parent != null && parent != sid && isInSubtree parent
+              );
+            isAncestor =
+              sid:
+              let
+                parent = scopeParent.${hostScopeId} or null;
+              in
+              sid == parent || (parent != null && parent != hostScopeId && isAncestorOf scopeParent sid parent);
+            isRelevant = sid: isInSubtree sid || isAncestor sid;
+            subtreeScopeIds = builtins.filter isInSubtree allScopeIds;
+            relevantScopeIds = builtins.filter isRelevant allScopeIds;
+            scopeEntityClassMap = scopeEntityClass null;
+            subtreeContexts = lib.genAttrs subtreeScopeIds (
+              sid:
+              let
+                base = augmentedScopeContexts.${sid};
+                entityCls = scopeEntityClassMap.${sid} or null;
+              in
+              if !(base ? class) && entityCls != null then
+                base // { class = entityCls; }
+              else if !(base ? class) then
+                base // { class = hostClass; }
+              else
+                base
+            );
+            subtreeClassImports = lib.genAttrs subtreeScopeIds (sid: scopedClassImportsRaw.${sid} or { });
+            subtreeProvides = lib.filterAttrs (sid: _: isRelevant sid) scopedProvides;
+            subtreeRoutes = lib.filterAttrs (sid: _: isRelevant sid) scopedRoutes;
+            relevantContexts = lib.genAttrs relevantScopeIds (sid: augmentedScopeContexts.${sid});
+            subtreePhase1 = wrapPerScope ctx subtreeContexts subtreeClassImports;
+            subtreePhase2 = applyProvides ctx relevantContexts subtreeProvides subtreePhase1;
+            subtreePhase3 =
+              applyRoutes fxResolveFn ctx relevantContexts hostScopeId scopeParent subtreeRoutes
+                subtreePhase2;
+          in
+          extractSubtreeModules subtreePhase3.perScope scopeParent hostScopeId hostClass
+        else
+          null;
+      modules =
+        if preWalkedModules != null then
+          preWalkedModules
+        else
+          lib.optional (spec ? mainModule) spec.mainModule;
+    in
+    if spec ? pkgs then
+      {
+        inherit (spec) pkgs;
+        inherit modules;
+      }
+    else
+      {
+        inherit modules;
+      }
+      // lib.optionalAttrs (spec ? system) {
+        modules = modules ++ [
+          { nixpkgs.hostPlatform = lib.mkDefault spec.system; }
+        ];
+      };
+
   # Phase 4: Apply entity instantiation.
   # When hosts were walked in the flake pipeline (via resolve.to "host"),
   # re-run assembly phases per host subtree with the host as rootScopeId.
   # This produces correct routing (identical to per-host fxResolve) while
   # reusing the walk's scope data — including sibling visibility for pipe.collect.
+  #
+  # Lazy: spec.instantiate is NOT called eagerly. Each output leaf is a thunk
+  # that calls spec.instantiate only when accessed (e.g., when someone reads
+  # config.flake.nixosConfigurations.cortex). This avoids evaluating all hosts
+  # when only one is needed.
   applyInstantiates =
     {
       scopedInstantiates,
-      # Raw walk data for per-host-subtree assembly.
       augmentedScopeContexts,
       scopedClassImportsRaw,
       scopedProvides,
@@ -269,9 +361,24 @@ let
     }:
     classImports:
     let
+      mkArgs = mkInstantiateArgs {
+        inherit
+          augmentedScopeContexts
+          scopedClassImportsRaw
+          scopedProvides
+          scopedRoutes
+          scopeParent
+          scopeEntityClass
+          fxResolveFn
+          ctx
+          ;
+      };
+
       allInstantiates = lib.concatLists (lib.attrValues scopedInstantiates);
-      allScopeIds = builtins.attrNames augmentedScopeContexts;
-      instantiateModules = lib.concatMap (
+
+      # Build spec descriptors: { path, system, spec } without calling instantiate.
+      # concatMap is strict in the list but the instantiate thunk is deferred.
+      specDescriptors = lib.concatMap (
         spec:
         let
           hasOutput = (spec.intoAttr or [ ]) != [ ];
@@ -279,93 +386,11 @@ let
         if !hasOutput then
           [ ]
         else
-          let
-            hostClass = spec.class or "nixos";
-            rawHostScopeId = findHostScopeId scopeParent allScopeIds spec;
-            # Fall back to source scope when no entity scope matches.
-            # This allows policy.instantiate to collect from any scope level
-            # (e.g., flake-system scope for perSystem class collection).
-            hostScopeId = if rawHostScopeId != null then rawHostScopeId else spec.sourceScopeId;
-            # Re-run assembly phases for the host subtree with correct rootScopeId.
-            preWalkedModules =
-              if hostScopeId != null then
-                let
-                  # Filter walk data to this host's subtree + ancestors.
-                  # Subtree: host scope + all descendants (users, etc.)
-                  # Ancestors: parent scopes up to root (flake-system, flake)
-                  # Excludes sibling subtrees (other hosts) to prevent cross-contamination.
-                  isInSubtree =
-                    sid:
-                    sid == hostScopeId
-                    || (
-                      let
-                        parent = scopeParent.${sid} or null;
-                      in
-                      parent != null && parent != sid && isInSubtree parent
-                    );
-                  isAncestor =
-                    sid:
-                    let
-                      parent = scopeParent.${hostScopeId} or null;
-                    in
-                    sid == parent || (parent != null && parent != hostScopeId && isAncestorOf scopeParent sid parent);
-                  isRelevant = sid: isInSubtree sid || isAncestor sid;
-                  subtreeScopeIds = builtins.filter isInSubtree allScopeIds;
-                  relevantScopeIds = builtins.filter isRelevant allScopeIds;
-                  scopeEntityClassMap = scopeEntityClass null;
-                  subtreeContexts = lib.genAttrs subtreeScopeIds (
-                    sid:
-                    let
-                      base = augmentedScopeContexts.${sid};
-                      entityCls = scopeEntityClassMap.${sid} or null;
-                    in
-                    if !(base ? class) && entityCls != null then
-                      base // { class = entityCls; }
-                    else if !(base ? class) then
-                      base // { class = hostClass; }
-                    else
-                      base
-                  );
-                  subtreeClassImports = lib.genAttrs subtreeScopeIds (sid: scopedClassImportsRaw.${sid} or { });
-                  subtreeProvides = lib.filterAttrs (sid: _: isRelevant sid) scopedProvides;
-                  subtreeRoutes = lib.filterAttrs (sid: _: isRelevant sid) scopedRoutes;
-                  relevantContexts = lib.genAttrs relevantScopeIds (sid: augmentedScopeContexts.${sid});
-                  subtreePhase1 = wrapPerScope ctx subtreeContexts subtreeClassImports;
-                  subtreePhase2 = applyProvides ctx relevantContexts subtreeProvides subtreePhase1;
-                  subtreePhase3 =
-                    applyRoutes fxResolveFn ctx relevantContexts hostScopeId scopeParent subtreeRoutes
-                      subtreePhase2;
-                in
-                extractSubtreeModules subtreePhase3.perScope scopeParent hostScopeId hostClass
-              else
-                null;
-            modules =
-              if preWalkedModules != null then
-                preWalkedModules
-              else
-                lib.optional (spec ? mainModule) spec.mainModule;
-            instantiateArgs =
-              if spec ? pkgs then
-                {
-                  inherit (spec) pkgs;
-                  inherit modules;
-                }
-              else
-                {
-                  inherit modules;
-                }
-                // lib.optionalAttrs (spec ? system) {
-                  modules = modules ++ [
-                    { nixpkgs.hostPlatform = lib.mkDefault spec.system; }
-                  ];
-                };
-            evaluated = spec.instantiate instantiateArgs;
-          in
           [
             {
               path = [ "flake" ] ++ spec.intoAttr;
-              value = evaluated;
               system = spec.system or null;
+              inherit spec;
             }
           ]
       ) allInstantiates;
@@ -379,7 +404,9 @@ let
       # are accessible (e.g. homeConfigurations."ben@x86_64-linux").
       # Same-entity duplicates (e.g. fleet + direct policy) are left as-is
       # since they produce compatible modules.
-      disambiguatedModules =
+      #
+      # Only inspects path and system metadata — never touches spec.instantiate.
+      disambiguated =
         let
           pathStr = builtins.concatStringsSep ".";
           grouped = builtins.foldl' (
@@ -388,7 +415,7 @@ let
               key = pathStr entry.path;
             in
             acc // { ${key} = (acc.${key} or [ ]) ++ [ entry ]; }
-          ) { } instantiateModules;
+          ) { } specDescriptors;
           resolve =
             _: entries:
             if builtins.length entries <= 1 then
@@ -411,9 +438,6 @@ let
                 ) entries
               else
                 # Same entity via multiple policy paths: deduplicate.
-                # Warn when more than one distinct instantiate spec targets the
-                # same output path on the same system — this can silently shadow
-                # one entity's configuration with another's.
                 let
                   entry = lib.last entries;
                 in
@@ -425,12 +449,10 @@ let
         in
         lib.concatLists (lib.mapAttrsToList resolve grouped);
 
-      # Merge all instantiate outputs into a single module via recursiveUpdate.
-      # After disambiguation, each output path appears at most once, so
-      # recursiveUpdate only merges attrset structure across different paths
-      # (e.g., homeConfigurations vs nixosConfigurations), not across
-      # conflicting evaluations of the same entity.
-      instantiateConfigs = map (entry: lib.setAttrByPath entry.path entry.value) disambiguatedModules;
+      # Build lazy output tree.  Each leaf calls spec.instantiate on first access.
+      instantiateConfigs = map (
+        entry: lib.setAttrByPath entry.path (entry.spec.instantiate (mkArgs entry.spec))
+      ) disambiguated;
     in
     classImports
     // {
@@ -458,102 +480,69 @@ let
       scopedProvides = result.state.scopedProvides null;
       scopedRoutes = result.state.scopedRoutes null;
 
-      # Pipe-data-free host configs for cross-host config thunk resolution.
-      # Uses original (non-augmented) scope contexts so modules don't receive
-      # pipe data args, breaking the cycle: assemblePipes → hostConfigs → evalModules → pipe data.
-      # Local thunks are marked and resolved inside evalModules via the fixpoint config.
-      hostConfigs =
+      # Scan raw pipe values for config-dependent thunks (functions taking
+      # { config, ... }).  If none exist, hostConfigs stays null and
+      # assemblePipes skips cross-host instantiation entirely.
+      isConfigDependent = val: builtins.isFunction val && (builtins.functionArgs val) ? config;
+      hasAnyConfigThunk =
         let
-          allInstantiates = lib.concatLists (lib.attrValues (result.state.scopedInstantiates null));
-          allScopeIds = builtins.attrNames scopeContexts;
-          specsByHost = builtins.listToAttrs (
-            lib.concatMap (
-              spec:
-              let
-                hasOutput = (spec.intoAttr or [ ]) != [ ];
-                hostScopeId = if hasOutput then findHostScopeId scopeParent allScopeIds spec else null;
-              in
-              if hostScopeId == null then
-                [ ]
-              else
-                [
-                  {
-                    name = hostScopeId;
-                    value = spec;
-                  }
-                ]
-            ) allInstantiates
-          );
+          # Values may be lists of entries, raw functions, or pipe entry
+          # records ({ __isPipeEntry; module = <fn>; ... }).
+          checkVal =
+            v:
+            if builtins.isList v then
+              builtins.any checkVal v
+            else if builtins.isAttrs v && v ? module then
+              isConfigDependent v.module
+            else
+              isConfigDependent v;
         in
-        lib.mapAttrs (
-          hostScopeId: spec:
+        builtins.any (scopeImports: builtins.any checkVal (lib.attrValues scopeImports)) (
+          lib.attrValues scopedClassImportsRaw
+        );
+
+      # Pipe-data-free host configs for cross-host config thunk resolution.
+      # Only computed when config-dependent thunks actually exist in the pipe
+      # data.  When null, resolveThunks in assemblePipes short-circuits.
+      hostConfigs =
+        if !hasAnyConfigThunk then
+          null
+        else
           let
-            hostClass = spec.class or "nixos";
-            isInSubtree =
-              sid:
-              sid == hostScopeId
-              || (
+            allInstantiates = lib.concatLists (lib.attrValues (result.state.scopedInstantiates null));
+            allScopeIds = builtins.attrNames scopeContexts;
+            specsByHost = builtins.listToAttrs (
+              lib.concatMap (
+                spec:
                 let
-                  parent = scopeParent.${sid} or null;
+                  hasOutput = (spec.intoAttr or [ ]) != [ ];
+                  hostScopeId = if hasOutput then findHostScopeId scopeParent allScopeIds spec else null;
                 in
-                parent != null && parent != sid && isInSubtree parent
-              );
-            isAncestor =
-              sid:
-              let
-                parent = scopeParent.${hostScopeId} or null;
-              in
-              sid == parent || (parent != null && parent != hostScopeId && isAncestorOf scopeParent sid parent);
-            isRelevant = sid: isInSubtree sid || isAncestor sid;
-            subtreeScopeIds = builtins.filter isInSubtree allScopeIds;
-            relevantScopeIds = builtins.filter isRelevant allScopeIds;
-            scopeEntityClassMap = (result.state.scopeEntityClass or (_: { })) null;
-            subtreeContexts = lib.genAttrs subtreeScopeIds (
-              sid:
-              let
-                base = scopeContexts.${sid};
-                entityCls = scopeEntityClassMap.${sid} or null;
-              in
-              if !(base ? class) && entityCls != null then
-                base // { class = entityCls; }
-              else if !(base ? class) then
-                base // { class = hostClass; }
-              else
-                base
+                if hostScopeId == null then
+                  [ ]
+                else
+                  [
+                    {
+                      name = hostScopeId;
+                      value = spec;
+                    }
+                  ]
+              ) allInstantiates
             );
-            subtreeClassImports = lib.genAttrs subtreeScopeIds (sid: scopedClassImportsRaw.${sid} or { });
-            subtreeProvides = lib.filterAttrs (sid: _: isRelevant sid) scopedProvides;
-            subtreeRoutes = lib.filterAttrs (sid: _: isRelevant sid) scopedRoutes;
-            relevantContexts = lib.genAttrs relevantScopeIds (sid: scopeContexts.${sid});
-            subtreePhase1 = wrapPerScope ctx subtreeContexts subtreeClassImports;
-            subtreePhase2 = applyProvides ctx relevantContexts subtreeProvides subtreePhase1;
-            subtreePhase3 =
-              applyRoutes (fxResolve mkPipeline) ctx relevantContexts hostScopeId scopeParent subtreeRoutes
-                subtreePhase2;
-            preWalkedModules = extractSubtreeModules subtreePhase3.perScope scopeParent hostScopeId hostClass;
-            modules =
-              if preWalkedModules != null then
-                preWalkedModules
-              else
-                lib.optional (spec ? mainModule) spec.mainModule;
-            instantiateArgs =
-              if spec ? pkgs then
-                {
-                  inherit (spec) pkgs;
-                  inherit modules;
-                }
-              else
-                {
-                  inherit modules;
-                }
-                // lib.optionalAttrs (spec ? system) {
-                  modules = modules ++ [
-                    { nixpkgs.hostPlatform = lib.mkDefault spec.system; }
-                  ];
-                };
+            mkArgs = mkInstantiateArgs {
+              augmentedScopeContexts = scopeContexts;
+              inherit
+                scopedClassImportsRaw
+                scopedProvides
+                scopedRoutes
+                scopeParent
+                ;
+              scopeEntityClass = result.state.scopeEntityClass or (_: { });
+              fxResolveFn = fxResolve mkPipeline;
+              inherit ctx;
+            };
           in
-          (spec.instantiate instantiateArgs).config
-        ) specsByHost;
+          lib.mapAttrs (_: spec: (spec.instantiate (mkArgs spec)).config) specsByHost;
 
       # Assemble pipe data into scope contexts before wrapping.
       # Local config thunks are marked for deferred resolution inside evalModules.

--- a/nix/lib/policy-effects.nix
+++ b/nix/lib/policy-effects.nix
@@ -101,7 +101,10 @@ in
   # Tier 1 delivery — replaces den.batteries.forward for the common case.
   route = spec: {
     __policyEffect = "route";
-    value = spec;
+    value = {
+      path = [ ];
+    }
+    // spec;
   };
 
   # Request post-pipeline instantiation of an entity's class content.
@@ -166,6 +169,10 @@ in
     };
     collect = pred: {
       __pipeStage = "collect";
+      fn = pred;
+    };
+    collectAll = pred: {
+      __pipeStage = "collectAll";
       fn = pred;
     };
   };

--- a/nix/lib/resolve-entity.nix
+++ b/nix/lib/resolve-entity.nix
@@ -51,7 +51,7 @@ let
         else if aspectKindSet ? ${name} then
           [
             {
-              __fn = c: c.${name}.aspect;
+              __fn = c: c.${name}.aspect or { };
               __args = {
                 ${name} = false;
               };

--- a/templates/ci/modules/features/pipes.nix
+++ b/templates/ci/modules/features/pipes.nix
@@ -222,5 +222,46 @@
         expected = "no-ports";
       }
     );
+
+    # Parametric pipe values with unsatisfied required args pass through
+    # unresolved instead of crashing (e.g. quirk needing pkgs at a scope
+    # without pkgs).
+    test-pipe-unsatisfied-parametric-passthrough = denTest (
+      { den, igloo, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+        den.quirks.build-info.description = "Build info requiring system args";
+
+        den.aspects.igloo = {
+          includes = [
+            den.aspects.producer
+            den.aspects.consumer
+          ];
+        };
+
+        den.aspects.producer = {
+          build-info =
+            { pkgs, ... }:
+            {
+              name = pkgs.hello.name;
+            };
+        };
+
+        den.aspects.consumer = {
+          nixos =
+            { build-info, ... }:
+            {
+              networking.hostName =
+                if builtins.length build-info == 1 && builtins.isFunction (builtins.head build-info) then
+                  "passthrough"
+                else
+                  "resolved";
+            };
+        };
+
+        expr = igloo.networking.hostName;
+        expected = "passthrough";
+      }
+    );
   };
 }


### PR DESCRIPTION
## Summary

Backport of perf and fix commits from the den-lazy branch, independent of the gen-schema migration.

### Performance

- **Closure chain elimination** — state helpers (`scopedAppend`/`scopedMerge`/etc.) stored accumulated state behind `_: ...` thunks, creating O(N) closure chains. N reads = O(N²). Fix: materialise the previous state eagerly outside the thunk. Cold eval: **-17%**, memory: **-70%**, attrset copies: **-88%**.
- **Lazy instantiation** — `applyInstantiates` and `hostConfigs` now defer `spec.instantiate` behind thunks so hosts are only evaluated when accessed. Eliminates unnecessary NixOS config evaluation for multi-host flakes.

### Fixes

- Safe fallback when entity kind has no aspect defined
- Default `path=[]` in `policy.route` constructor
- Skip unsatisfied parametric pipe values in `resolveLocalParametric`

### Feature

- `pipe.collectAll` — collects from all scopes matching a predicate

## Motivation

The closure chain fix directly resolves stack overflow in nix-unit sandbox evaluation for configs with deep NixOS module trees (e.g. configs using stylix + plasma-manager + sops-nix). Verified against a users config where `nix flake check` was failing with stack overflow.

## Test plan

- [x] 803/803 CI tests pass
- [x] `nix flake check` passes on oceangreendev config (previously stack overflow)
- [x] Formatting clean