### PR TITLE
fix: don't force aspect content during key classification (#580)

### DIFF
--- a/nix/lib/aspects/fx/key-classification.nix
+++ b/nix/lib/aspects/fx/key-classification.nix
@@ -52,20 +52,29 @@ let
       && builtins.any (k: builtins.isAttrs v.${k} || lib.isFunction v.${k}) (builtins.attrNames v)
     );
 
-  hasRecognizedSubKeys =
-    depth: val:
+  # A nested aspect carries aspect *structure*: a registered class key (with
+  # class-like content), a pipe key, or a structural aspect key
+  # (includes/provides/meta/…).  Detection inspects attr NAMES only and forces
+  # a sub-value solely when its name matches a registered class — never under
+  # arbitrary content keys.  Forcing content here would evaluate user values
+  # mid-pipeline; a value reading the flake's own `self.outputs` would then
+  # re-enter the flake `self` fixpoint → infinite recursion (#580).
+  #
+  # Depth-1 suffices: sub-aspects are never auto-walked (see compile-static) —
+  # they activate via explicit `includes`, so every nested aspect exposes a
+  # recognized key at its own top level (a class key or `includes`).
+  isNestedKey =
+    aspect: k:
+    let
+      val = den.lib.aspects.fx.contentUtil.unwrapContentValuesForClassification aspect.${k};
+    in
     builtins.isAttrs val
     && builtins.any (
       sk:
-      (classRegistry ? ${sk} && looksLikeClassContent val.${sk})
-      || (depth > 0 && builtins.isAttrs (val.${sk} or null) && hasRecognizedSubKeys (depth - 1) val.${sk})
+      structuralKeysSet ? ${sk}
+      || pipeRegistry ? ${sk}
+      || (classRegistry ? ${sk} && looksLikeClassContent val.${sk})
     ) (builtins.attrNames val);
-
-  isNestedKey =
-    aspect: k:
-    hasRecognizedSubKeys 3 (
-      den.lib.aspects.fx.contentUtil.unwrapContentValuesForClassification aspect.${k}
-    );
 
   classifyKeys =
     targetClass: aspect:

--- a/templates/ci/modules/features/deadbugs/issue-580-self-output-classification-recursion.nix
+++ b/templates/ci/modules/features/deadbugs/issue-580-self-output-classification-recursion.nix
@@ -1,0 +1,73 @@
+# Regression for #580: infinite recursion when an UNREGISTERED aspect key
+# consumes a flake self-output (`self.outputs.*`).
+#
+# Reproduction: https://github.com/musjj/recursion-bug
+#   den.default.nixpkgs.overlays = builtins.attrValues self.outputs.overlays;
+#
+# Root cause — key-classification.nix `hasRecognizedSubKeys`:
+# to decide whether an unregistered key (here `nixpkgs`) is a nested aspect,
+# it inspects each sub-key with `builtins.isAttrs (val.${sk} or null)`, which
+# FORCES the sub-key's value to WHNF.  Classification runs while the flake
+# output set is still being assembled, so forcing a value that reads
+# `self.outputs` re-enters the flake `self` fixpoint → infinite recursion.
+#
+# Registered class keys (nixos/darwin/homeManager) bypass `isNestedKey`
+# entirely, so their content stays lazy until NixOS-module build time (after
+# the `self` fixpoint has resolved) — they never trigger the cycle.  This is
+# why the bug is invisible for normal class content and only bites
+# unregistered keys like `nixpkgs`.  The forwarder / homeManager user in the
+# original report were incidental — neither is required to trigger it.
+#
+# `config.flake` is the in-harness analogue of `self.outputs`.
+{ denTest, ... }:
+{
+  flake.tests.issue-580-self-output-classification-recursion = {
+
+    # The bug: unregistered `nixpkgs` key whose value reads a flake
+    # self-output.  Classification forces the value → self-fixpoint cycle.
+    test-unregistered-key-self-output = denTest (
+      {
+        den,
+        config,
+        igloo,
+        ...
+      }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+        den.default = {
+          nixpkgs.overlays = builtins.attrValues (config.flake.nixosConfigurations or { });
+          nixos.networking.hostName = "no-recursion";
+        };
+
+        expr = igloo.networking.hostName;
+        expected = "no-recursion";
+      }
+    );
+
+    # Contrast / boundary guard: the SAME self-output reference under a
+    # registered class key stays lazy and evaluates fine.  Proves the cycle
+    # is specific to unregistered-key classification, and guards against a
+    # fix that over-corrects by forcing registered content too.
+    test-registered-key-self-output = denTest (
+      {
+        den,
+        config,
+        igloo,
+        ...
+      }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+        den.default = {
+          nixos.networking.hostName = "ok-${
+            toString (builtins.length (builtins.attrValues (config.flake.nixosConfigurations or { })))
+          }";
+          nixos.users.users.tux.isNormalUser = true;
+        };
+
+        expr = igloo.networking.hostName;
+        expected = "ok-1";
+      }
+    );
+
+  };
+}


### PR DESCRIPTION
## Problem

Fixes #580. Consuming a flake self-output from an **unregistered** aspect key threw `infinite recursion encountered`:

```nix
den.default.nixpkgs.overlays = builtins.attrValues self.outputs.overlays;
```

Worked in v0.16; regressed with the fx-pipeline rewrite (#475). Present on `main` — independent of #575.

## Root cause

`key-classification.nix` decided whether an unregistered key was a nested sub-aspect by descending through its value with `builtins.isAttrs (val.${sk} or null)`, which **forces every sub-value to WHNF**. Classification runs while the flake output set is being assembled, so forcing a value that reads `self.outputs` re-enters the flake `self` fixpoint (`outputs = flake.outputs (inputs // { self = result; })`) → infinite recursion.

Registered class keys (`nixos`/`darwin`/`homeManager`) bypass this path and stay lazy until NixOS-module build time (after the `self` fixpoint resolves), which is why only unregistered keys like `nixpkgs` cycled. `builtins.tryEval` cannot guard it — it does not catch infinite recursion.

## Fix

Detect nested aspects from recognized key **names** (class / pipe / structural like `includes`) at the value's top level, forcing a sub-value only when its name matches a registered class — never under arbitrary content keys.

This is sound because nested sub-aspects are never auto-walked (see `compile-static`); they activate via explicit `includes`, so every nested aspect exposes a recognized key at its own top level. The value-forcing descent was unnecessary.

## Notes on the original report

Verified empirically: the forwarder and the `homeManager` user were incidental — the minimal trigger is just an unregistered key reading `self.outputs.*`. Also confirmed this is **not** the stack-overflow addressed by #579 (distinct error class; the recursion persists with #579 merged).

## Validation

- New regression test `deadbugs/issue-580-self-output-classification-recursion.nix` (repro + a registered-key boundary guard): infinite recursion → ✅ 2/2
- Real-world repro flake (`musjj/recursion-bug`, full forwarder + homeManager + `self.outputs.overlays`): infinite recursion → evaluates
- Full CI: **837/837** ✅