### PR TITLE
fix: order simple routes before forwards that consume their class

### DIFF
--- a/nix/lib/aspects/fx/route/apply.nix
+++ b/nix/lib/aspects/fx/route/apply.nix
@@ -282,22 +282,28 @@ let
     routes:
     let
       indexed = lib.imap0 (i: r: { inherit i r; }) routes;
-      # Build producer map: intoClass@scope → [route indices]
+      # Build producer map: intoClass@scope → [route indices].  Both simple
+      # routes and complex forwards are producers: a simple route injecting
+      # into a home-env class (e.g. homeManager) feeds the complex forward that
+      # carries that class to its host output (makeHomeEnv's userForward).
+      # Complex forwards read from the accumulating fold state, so any producer
+      # of their fromClass must fire first or the injected content is lost.
       producerMap = builtins.foldl' (
         acc:
         { i, r }:
-        if r.__complexForward or false then
-          let
-            key = "${r.intoClass}@${r.sourceScopeId}";
-          in
-          acc // { ${key} = (acc.${key} or [ ]) ++ [ i ]; }
-        else
-          acc
+        let
+          key = "${r.intoClass}@${r.sourceScopeId}";
+        in
+        acc // { ${key} = (acc.${key} or [ ]) ++ [ i ]; }
       ) { } indexed;
-      # A complex forward is "depends on producers" when its fromClass@scope
-      # has entries in producerMap (meaning another forward produces into it).
+      # A complex forward "depends on producers" when its fromClass@scope has
+      # producer entries from *other* routes (meaning another route produces
+      # into the class it consumes).  Simple routes read the original per-scope
+      # data, not the fold state, so they never depend on ordering themselves.
       hasDeps =
-        { i, r }: (r.__complexForward or false) && producerMap ? "${r.fromClass}@${r.sourceScopeId}";
+        { i, r }:
+        (r.__complexForward or false)
+        && builtins.any (j: j != i) (producerMap."${r.fromClass}@${r.sourceScopeId}" or [ ]);
       # Partition: routes without deps first, routes with deps last.
       # This is a single-level toposort (sufficient for A→B chains).
       noDeps = builtins.filter (ir: !hasDeps ir) indexed;

--- a/templates/ci/modules/features/deadbugs/netadr-hjem-route.nix
+++ b/templates/ci/modules/features/deadbugs/netadr-hjem-route.nix
@@ -1,0 +1,109 @@
+# Regression: a simple `policy.route` into a home-env class (homeManager / hjem)
+# was silently dropped.  Home-env classes are consumed by makeHomeEnv's
+# `userForward` (a __complexForward routing homeManager -> host.class).  The
+# route toposort only treated __complexForward routes as producers, so the
+# consuming forward could run BEFORE the simple route injected its content,
+# losing it.  Models netadr's hjemLinux -> hjem policy (homeManager == hjem).
+{ denTest, ... }:
+{
+  flake.tests.netadr-hjem-route = {
+
+    # User-scope source, policy fires at user scope (host+user signature).
+    test-route-user-scope-usersig = denTest (
+      {
+        den,
+        lib,
+        tuxHm,
+        ...
+      }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.classes.srcLinux.description = "Linux source class";
+
+        den.policies.srcLinux-to-hm =
+          { host, user, ... }:
+          lib.optionals (lib.hasSuffix "-linux" host.system) [
+            (den.lib.policy.route {
+              fromClass = "srcLinux";
+              intoClass = "homeManager";
+              path = [ ];
+            })
+          ];
+        den.default.includes = [ den.policies.srcLinux-to-hm ];
+
+        den.aspects.tux.srcLinux.home.sessionVariables.ROUTED = "yes";
+
+        expr = tuxHm.home.sessionVariables.ROUTED or "MISSING";
+        expected = "yes";
+      }
+    );
+
+    # netadr's exact shape: host-signature policy, source on a user self-provide.
+    test-route-user-scope-provide = denTest (
+      {
+        den,
+        lib,
+        tuxHm,
+        ...
+      }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.classes.srcLinux.description = "Linux source class";
+
+        den.policies.srcLinux-to-hm =
+          { host, ... }:
+          lib.optionals (lib.hasSuffix "-linux" host.system) [
+            (den.lib.policy.route {
+              fromClass = "srcLinux";
+              intoClass = "homeManager";
+              path = [ ];
+            })
+          ];
+        den.default.includes = [ den.policies.srcLinux-to-hm ];
+
+        den.aspects.tux = {
+          includes = [ den.aspects.tux._.prog ];
+          _.prog.srcLinux.home.sessionVariables.ROUTED = "yes";
+        };
+
+        expr = tuxHm.home.sessionVariables.ROUTED or "MISSING";
+        expected = "yes";
+      }
+    );
+
+    # Different resolving scope: a standalone home entity (den.homes), which
+    # resolves at the `home` scope and is assembled via its own instantiate
+    # (not the user-scope userForward).  Confirms route -> homeManager is not
+    # user-scope-specific.
+    test-route-standalone-home-scope = denTest (
+      { den, config, ... }:
+      {
+        den.homes.x86_64-linux.tux = { };
+        den.default.homeManager.home.stateVersion = "25.11";
+
+        den.classes.srcLinux.description = "Linux source class";
+
+        den.policies.srcLinux-to-hm =
+          { home, ... }:
+          [
+            (den.lib.policy.route {
+              fromClass = "srcLinux";
+              intoClass = "homeManager";
+              path = [ ];
+            })
+          ];
+        den.default.includes = [
+          den.provides.define-user
+          den.policies.srcLinux-to-hm
+        ];
+
+        den.aspects.tux.srcLinux.home.sessionVariables.ROUTED = "yes";
+
+        expr = config.flake.homeConfigurations.tux.config.home.sessionVariables.ROUTED or "MISSING";
+        expected = "yes";
+      }
+    );
+  };
+}


### PR DESCRIPTION
## Problem

A simple `den.lib.policy.route` injecting into a **home-env class** (`homeManager`, or a custom `hjem` class) was silently dropped when the source class lived on a **user** aspect. Reported against a config whose `hjemLinux → hjem` policy never forwarded the user's class data.

## Root cause

Home-env classes are not assembled in the pipeline pass where the route runs. `home-env.nix:makeHomeEnv` carries the class to its host output via `userForward` — a `__complexForward` (`fromClass = homeManager`, into `host.class` at `home-manager.users.<n>`). `applyComplexRoute` reads from the **accumulating fold state**, so any route producing into its `fromClass` must run first.

`topoSortRoutes` only registered `__complexForward` routes in its `producerMap`. A *simple* route producing into `homeManager` was invisible, so the consuming forward was never ordered after it — and when it ran first, the injected content was already gone.

This is why `route → nixos` (a host-terminal class) always worked while `route → homeManager` never did, regardless of scope, schema, or policy signature.

## Fix

Treat **every** route as a producer in `topoSortRoutes`, so a complex forward consuming a class is ordered after any route producing into it. Self-references are excluded when computing dependencies (also removes a latent spurious self-dependency).

## Verification

- New regression suite `deadbugs/netadr-hjem-route.nix` covers the user-scope-signature and user-self-provide (the reported config's exact shape) cases — both fail before, pass after.
- Full CI green: **837/837**, including the `#567` forward-ordering, `route`, and `forward-*` suites.