### PR TITLE
fix: forwarded content overwritten across scopes (#583)

### DIFF
--- a/nix/lib/aspects/fx/route/apply.nix
+++ b/nix/lib/aspects/fx/route/apply.nix
@@ -7,8 +7,30 @@
   collectClassMods,
 }:
 let
+  # Root-scope `fromClass` content a child-scope forward may pull in. When
+  # `fromClass` is a class some entity in the chain owns, root content under it
+  # is that entity's own declaration, not aggregation fodder — restrict to
+  # shared `den.default` (host class content reaches users opt-in via
+  # host-aspects). A custom forward-only class (e.g. `atuin`) only exists to
+  # feed forwards, so its root content is a legitimate source; keep it in full.
+  filterRootModules =
+    scopeContexts: spec: rootModules: isDenDefaultModule:
+    let
+      childCtx = scopeContexts.${spec.sourceScopeId} or { };
+      # Classes owned by each entity kind in the chain. Total over kinds so the
+      # filter never falls open for a non-user-owned scope (host, standalone home).
+      ownedClasses =
+        (childCtx.user.classes or [ ])
+        ++ lib.optional (childCtx ? host) childCtx.host.class
+        ++ lib.optional (childCtx ? home) childCtx.home.class;
+    in
+    if builtins.elem spec.fromClass ownedClasses then
+      builtins.filter isDenDefaultModule rootModules
+    else
+      rootModules;
+
   getCollectedSource =
-    acc: spec: rootScopeId: isDenDefaultModule:
+    acc: spec: rootScopeId: isDenDefaultModule: scopeContexts:
     let
       sid = spec.sourceScopeId;
     in
@@ -17,7 +39,7 @@ let
         ownModules = (acc.perScope.${sid} or { }).${spec.fromClass} or [ ];
         rootModules = (acc.perScope.${rootScopeId} or { }).${spec.fromClass} or [ ];
       in
-      builtins.filter isDenDefaultModule rootModules ++ ownModules
+      filterRootModules scopeContexts spec rootModules isDenDefaultModule ++ ownModules
     else
       acc.classImports.${spec.fromClass} or [ ];
 
@@ -61,7 +83,7 @@ let
     }:
     let
       spec = route;
-      collected = getCollectedSource acc spec rootScopeId isDenDefaultModule;
+      collected = getCollectedSource acc spec rootScopeId isDenDefaultModule scopeContexts;
       sourceModules =
         if collected != [ ] then collected else resolveSourceFallback spec fxResolve scopeContexts ctx;
       sourceModule = spec.mapModule { imports = sourceModules; };

--- a/templates/ci/modules/features/deadbugs/issue-583-forwarding-overwrite.nix
+++ b/templates/ci/modules/features/deadbugs/issue-583-forwarding-overwrite.nix
@@ -1,0 +1,80 @@
+# Two aspects both contribute to the `atuin` class. The `atuin` aspect forwards
+# its own `atuin` content into `programs.atuin` while `igloo` provides `atuin`
+# to its users and also contributes flags. Forwarded content from the provider
+# aspect must merge with the host's own contribution, not overwrite it.
+{ denTest, ... }:
+let
+  atuinModule =
+    { lib, ... }:
+    {
+      options.programs.atuin.flags = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ ];
+      };
+    };
+in
+{
+  flake.tests.deadbugs.issue-583-forwarding-overwrite = {
+
+    test-forwarded-flags-merge = denTest (
+      {
+        den,
+        lib,
+        igloo,
+        ...
+      }:
+      let
+        atuinClass =
+          { class, aspect-chain }:
+          den._.forward {
+            each = lib.singleton null;
+            fromClass = _: "atuin";
+            intoClass = _: "nixos";
+            intoPath = _: [
+              "programs"
+              "atuin"
+            ];
+            fromAspect = _: lib.head aspect-chain;
+            guard = _: true;
+          };
+      in
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.default.includes = [ den._.mutual-provider ];
+
+        den.aspects.atuin = {
+          includes = [
+            atuinClass
+          ];
+
+          atuin.flags = [
+            "--hello"
+          ];
+        };
+
+        den.aspects.igloo = {
+          nixos.imports = [ atuinModule ];
+
+          provides.to-users.includes = [
+            den.aspects.atuin
+          ];
+
+          atuin.flags = [
+            "--world"
+            "--baz"
+          ];
+        };
+
+        expr = lib.sort lib.lessThan igloo.programs.atuin.flags;
+
+        expected = [
+          "--baz"
+          "--hello"
+          "--world"
+        ];
+      }
+    );
+
+  };
+}


### PR DESCRIPTION
## Problem

Fixes #583. When two aspects contribute to the same forward source class and the forward fires at a child (user) scope while routing into a parent (host) class, the host's own contribution is silently dropped:

```nix
den.aspects.atuin = {
  includes = [ atuinClass ];   # forwards `atuin` → nixos programs.atuin
  atuin.flags = [ "--hello" ];
};
den.aspects.igloo = {
  provides.to-users.includes = [ den.aspects.atuin ];
  atuin.flags = [ "--world" "--baz" ];
};
```

Produces `programs.atuin.flags = [ "--hello" ]` instead of the merged `[ "--hello" "--world" "--baz" ]`.

Worked in v0.16; regressed with the fx-pipeline rewrite (#475).

## Root cause

`route/apply.nix:getCollectedSource` merges a complex forward's own-scope source modules with the root (host) scope's `fromClass` content, but filtered the root content unconditionally through `isDenDefaultModule` — keeping only `@default`-keyed modules. The host's own `atuin` content (module key `atuin@igloo`) is not a `den.default` module, so it was filtered out, leaving only the user-scope `--hello`.

That `@default`-only filter is **correct** for entity-owned classes: the home-manager battery's `homeManager → nixos` forward must not implicitly pull a host's own `homeManager` config into every user's home — that projection is opt-in via `host-aspects`. It is **wrong** for a custom forward-only class like `atuin`, whose host-scope content exists solely to be aggregated.

## Fix

Restrict root content to `@default` only when `fromClass` is a class an entity in the scope chain owns (`user.classes`, `host.class`, `home.class`, read from `scopeContexts`); otherwise keep the root content in full. The owned-class set is total over all three entity kinds so the decision never falls open for a non-user-owned scope.

The discriminator keys on `fromClass` rather than `intoClass` deliberately — `host-aspects.test-opt-in-only` and `user-host-mutual-config.test-host-owned-unidirectional` both forward `homeManager` into `nixos` yet must keep their opt-in projection semantics.

## Validation

- New regression test `deadbugs/issue-583-forwarding-overwrite.nix` (mirrors the report): overwrite → ✅ 1/1
- `host-aspects` ✅ 10/10 and `user-host-mutual-config` ✅ 9/9 — opt-in projection unchanged
- Full CI: **839/839** ✅
- Formatting clean