### PR TITLE
fix: correct flake output include to flake-system schema kind

### DIFF
--- a/docs/src/content/docs/reference/output.mdx
+++ b/docs/src/content/docs/reference/output.mdx
@@ -115,7 +115,7 @@ The following example are for `packages` but same applies for `checks`, `devShel
      # ANY Host or User aspect can produce outputs:
      # The flake-system-to-flake-os policy handles host fan-out.
      # To include aspects in flake outputs:
-     den.schema.flake-packages.includes = [ den.aspects.foo ];
+     den.schema.flake-system.includes = [ den.aspects.foo ];
      ```
 
 3. Use the `packages` class on your aspects:


### PR DESCRIPTION
## Problem

The reference page for flake outputs (`docs/src/content/docs/reference/output.mdx`) instructs:

```nix
den.schema.flake-packages.includes = [ den.aspects.foo ];
```

But `flake-packages` is not a registered schema kind. The registered routing kinds are `flake`, `flake-system`, `flake-parts`, and `default`. Because `den.schema` is a freeform `lazyAttrsOf schemaEntryType`, the bad kind is silently accepted and nothing ever resolves to it, so its includes are never walked. It does nothing.

This is what #586 hit. The aspect's package only appeared in `nix flake show` when a host happened to include the aspect, pulling it into a real instantiation path. Removing that host made the package vanish, because the documented `flake-packages` line was doing nothing.

## Fix

Point the example at `flake-system`, the kind that is actually instantiated (one scope per system, via the `to-systems` fan-out). Aspects included there resolve at each per-system scope, and the `to-packages`/`to-apps`/`to-checks`/`to-devShells` routes, also registered on `flake-system`, carry the class output to the flake.

## Verification

Against a minimal repro (aspect with a `packages` class key, no host):

- `den.schema.flake-packages.includes` gives no `packages` output at all
- `den.schema.flake-system.includes` exports `hello` for every system, no host required

Matches the workaround the reporter found.

Fixes #586.