### PR TITLE
docs: fix some typos

### DIFF
--- a/docs/src/content/docs/contributing.mdx
+++ b/docs/src/content/docs/contributing.mdx
@@ -110,5 +110,5 @@ Now, you can edit the `.mdx` files in `docs/src/content/docs` and see your chang
 One of the best forms of contribution does not even require submitting code. Hang out in our community
 channels and help others with onboarding to den!
 
-Thanks, You are awesome!
+Thanks, you are awesome!
 

--- a/docs/src/content/docs/maintainers.mdx
+++ b/docs/src/content/docs/maintainers.mdx
@@ -11,7 +11,7 @@ Maintaining an open-source project can be overwhelming for a single person, this
 
 Maintainers are all volunteers and there's no hard-expectations from them. We ask people to treat maintainers with respect, do not ask as if they had any responsibility to you. We all contribute our time and effort with good-will for the sake of helping Den and its users.
 
-Here's the list of Den current maintainers:
+Here's the list of current Den maintainers:
 
 - [`@vic`](https://github.com/vic)
 - [`@sini`](https://github.com/sini)
@@ -28,7 +28,7 @@ We prefer open communication whenever possible. And private messages only for se
 
 Everything related to Den issues or planning/designing new features should ideally be communicated openly. So other people can know how Den is being evolved and can also participate.
 
-All communication must be respectful and mindful of others. Specially when coming from maintainers. We do not have a social contract, but kindness and respect for each other is our only rule.
+All communication must be respectful and mindful of others. Especially when coming from maintainers. We do not have a social contract, but kindness and respect for each other is our only rule.
 
 ## Asking For `denTest`s
 
@@ -62,9 +62,9 @@ PRs automatically run our `just ci` tests.
 
 Review the design and code changes, try to think how these changes will impact Den. Make sure there's nothing suspicious and that code is understandable for you and other maintainers, ask for help if needed.
 
-Communicate with contributors to have a satisfying and best possible solution. Working does not equal good, specially when it comes to unsupervised code.
+Communicate with contributors to have a satisfying and best possible solution. Working does not equal good, especially when it comes to unsupervised code.
 
-When code is OK. Send a GitHub PR Approval.
+When code is OK, Send a GitHub PR Approval.
 
 Use the `allow-ci` so **all** integration tests are run on the branch.
 
@@ -104,7 +104,7 @@ Communicate the intent of making a release with one or two days of anticipation.
 
 This helps other people willing to have shipped features decide if they can make it to the next release.
 
-Any Den Maintainer can volunteer to publish a release, just communicate on who will do it.
+Any Den maintainer can volunteer to publish a release, just communicate on who will do it.
 
 ### Update Docs
 

--- a/docs/src/content/docs/motivation.mdx
+++ b/docs/src/content/docs/motivation.mdx
@@ -39,7 +39,7 @@ At that time [unify](https://codeberg.org/quasigod/unify) - the first dendritic 
 However, before adopting `unify`, I realized that my re-usability problem was not about syntax, not about how things are loaded from filesystem nor how they are wired at the flake level.
 **The problem was more about feature composability.**
 
-Being an fan of functional programming, the most composable things I know are functions.
+Being a fan of functional programming, the most composable things I know are functions.
 
 ## **An aspect in Den is a function**
 

--- a/docs/src/content/docs/releases.mdx
+++ b/docs/src/content/docs/releases.mdx
@@ -56,7 +56,7 @@ Docs: https://den.denful.dev/latest
 
 > Diff of changes since latest release: [latest...main](https://github.com/denful/den/compare/latest...main)
 
-This is intended for people that wishes to move only between release points.
+This is intended for people that wish to move only between release points.
 People still need to read `Release Notes` since they might contain important
 information on how Den is evolving.
 


### PR DESCRIPTION
A very small PR fixing some typos I noticed while reading the docs. It's not exhaustive at all of course, only the ones I've seen