### PR TITLE
feat: add batteries.user-modules

### DIFF
--- a/modules/aspects/batteries/user-aspects.nix
+++ b/modules/aspects/batteries/user-aspects.nix
@@ -1,0 +1,30 @@
+{ den, lib, ... }:
+let
+  description = ''
+    Projects all `host.class`es like `nixos` from the user's aspect tree onto
+    hosts that opt in. Requires the fx pipeline.
+
+    ## Usage
+
+      den.aspects.igloo.includes = [ den.batteries.user-aspects ];
+
+    Any user aspect that defines a `host.class` key will have that config
+    forwarded to the hosts's evaluation.
+  '';
+
+  from-user =
+    { host, user, ... }: [ (den.lib.policy.spawn { classes = [ host.class ]; }) ];
+in
+{
+  den.batteries.user-aspects = {
+    name = "user-aspects";
+    inherit description;
+    includes = [
+      {
+        __isPolicy = true;
+        name = "user-aspects-project";
+        fn = from-user;
+      }
+    ];
+  };
+}


### PR DESCRIPTION
Works exactly like batteries.host-modules but in reverse, allowing `host.class`es from the user aspect tree to be projected into onto hosts that include it.

# Test plan

I added this to my user aspect:
```nix
{
  den.aspects.sergio.nixos = { pkgs, ... }: {
    environment.systemPackages = [ pkgs.htop ];
  };
}
```
After that I rebuilt and saw no `htop` in my system as expected.

After including this (`icebear` is my main PC):
```nix
{ den, ... }: {
  den.aspects.icebear.includes = [ den.batteries.user-aspects ];
}
```

I get `htop` as expected.