### PR TITLE
feat: in-context hasAspect honors projected (delivered) scope state

### DIFF
--- a/nix/lib/aspects/default.nix
+++ b/nix/lib/aspects/default.nix
@@ -62,6 +62,18 @@ let
       self = wrapped;
     };
 
+  # Like resolve but also surfaces the per-scope path set, from one fx.handle.
+  fxResolveTreeWithPaths =
+    class: resolved:
+    let
+      wrapped = normalizeRoot resolved;
+      ctx = fx.aspect.ctxFromHandlers (resolved.__scopeHandlers or { });
+    in
+    fx.pipeline.fxResolveWithPaths {
+      inherit class ctx;
+      self = wrapped;
+    };
+
   # Like resolve but skips entity instantiation.
   # Use for nested resolution (e.g., extracting homeManager modules from a host tree).
   fxResolveTreeImports =
@@ -97,6 +109,7 @@ in
     policyTypes
     ;
   resolve = fxResolveTree;
+  resolveWithPaths = fxResolveTreeWithPaths;
   resolveImports = fxResolveTreeImports;
   resolveWithState = fxResolveTreeFull;
   inherit (hasAspect) hasAspectIn collectPathSet mkEntityHasAspect;

--- a/nix/lib/aspects/default.nix
+++ b/nix/lib/aspects/default.nix
@@ -112,7 +112,12 @@ in
   resolveWithPaths = fxResolveTreeWithPaths;
   resolveImports = fxResolveTreeImports;
   resolveWithState = fxResolveTreeFull;
-  inherit (hasAspect) hasAspectIn collectPathSet mkEntityHasAspect;
+  inherit (hasAspect)
+    hasAspectIn
+    collectPathSet
+    mkEntityHasAspect
+    mkProjectedHasAspect
+    ;
   mkAspectsType = typeCfg: lib.mapAttrs (_: v: v typeCfg) rawTypes;
   # Predicates exported directly (not through types mapAttrs which applies { } to each value).
   inherit (rawTypes)

--- a/nix/lib/aspects/fx/identity.nix
+++ b/nix/lib/aspects/fx/identity.nix
@@ -68,6 +68,19 @@ let
               // lib.optionalAttrs (baseKey != key) {
                 ${baseKey} = true;
               };
+            pathSetByScope =
+              _:
+              let
+                prev = (state.pathSetByScope or (_: { })) null;
+                scope = state.currentScope;
+                scopeSet = prev.${scope} or { };
+              in
+              prev
+              // {
+                ${scope} = scopeSet // {
+                  ${baseKey} = true;
+                };
+              };
           };
       };
   };

--- a/nix/lib/aspects/fx/pipeline.nix
+++ b/nix/lib/aspects/fx/pipeline.nix
@@ -135,6 +135,10 @@ let
     # --- Flat state (global by design, not scoped) ---
     seen = _: { };
     pathSet = _: { };
+    # Per-scope path set: scopeId → { basePathKey → true }. Byproduct of the
+    # structural walk, bucketed by the scope that owns each node. Powers the
+    # projected (in-context) hasAspect. Thunked to survive per-step deepSeq.
+    pathSetByScope = _: { };
 
     # --- Scope-partitioned output state (handlers write here) ---
     scopedClassImports = _: { };

--- a/nix/lib/aspects/fx/pipeline.nix
+++ b/nix/lib/aspects/fx/pipeline.nix
@@ -229,6 +229,7 @@ let
   resolveModule = import ./resolve.nix { inherit lib den; };
   inherit (resolveModule) wrapCollectedClasses;
   fxResolve = resolveModule.fxResolve mkPipeline;
+  fxResolveWithPaths = resolveModule.fxResolveWithPaths mkPipeline;
   fxResolveImports = resolveModule.fxResolveImports mkPipeline;
 in
 {
@@ -240,6 +241,7 @@ in
     mkScopeId
     fxFullResolve
     fxResolve
+    fxResolveWithPaths
     fxResolveImports
     wrapCollectedClasses
     ;

--- a/nix/lib/aspects/fx/policy/schema.nix
+++ b/nix/lib/aspects/fx/policy/schema.nix
@@ -75,21 +75,16 @@ let
       # would desync this lookup's key from the bucket key. Restrict to entity
       # kinds so the projected id matches `currentScope` regardless of enrichment.
       scopeId = mkScopeId (lib.getAttrs overrideKinds rawScopedCtx);
-      owner = rawScopedCtx.host or rawScopedCtx.${targetKind} or null;
-      ownerPathSet = if owner != null then owner.__pathSetByScope or { } else { };
+      # The host run buckets every user scope; a self-scoped entity (no host)
+      # uses its own. `or { }` covers an entity without a path set.
+      ownerPathSet =
+        rawScopedCtx.host.__pathSetByScope or rawScopedCtx.${targetKind}.__pathSetByScope or { };
       projected = den.lib.aspects.mkProjectedHasAspect {
         pathSetByScope = ownerPathSet;
         inherit scopeId;
       };
-      scopedCtx = builtins.foldl' (
-        acc: k:
-        acc
-        // {
-          ${k} = acc.${k} // {
-            hasAspect = projected;
-          };
-        }
-      ) rawScopedCtx overrideKinds;
+      scopedCtx =
+        rawScopedCtx // lib.genAttrs overrideKinds (k: rawScopedCtx.${k} // { hasAspect = projected; });
     in
     {
       inherit

--- a/nix/lib/aspects/fx/policy/schema.nix
+++ b/nix/lib/aspects/fx/policy/schema.nix
@@ -51,8 +51,45 @@ let
     let
       targetKind = resolveTargetKind entityKind schemaEffect;
       resolveBindings = schemaEffect.schema.value;
-      scopedCtx = enrichedCtx // resolveBindings;
+      rawScopedCtx = enrichedCtx // resolveBindings;
       entityClass = resolveEntityClass targetKind resolveBindings;
+
+      # In-context hasAspect answers PROJECTED membership: what is actually
+      # delivered into THIS scope, not the structural registry tree. The owning
+      # host's production run already bucketed every user scope's path set under
+      # `__pathSetByScope`; a self-scoped entity (no host) uses its own. The
+      # lookup is pure and forced lazily (e.g. at a class-module `mkIf`), so it
+      # never re-enters the resolve that produced the path set. Reading it from an
+      # `includes` position is the one cyclic case (same in-flight run): it forces
+      # the host's own `__resolveResult` and recurses — don't decide includes from
+      # projected membership.
+      #
+      # Only `.hasAspect` is replaced. `mkScopeId` keys off `.name`, so the
+      # derived `ctxNames`/`currentScope` are unperturbed by this wrapping.
+      overrideKinds = builtins.filter (
+        k: schemaEntityKindsSet ? ${k} && builtins.isAttrs (rawScopedCtx.${k} or null)
+      ) (builtins.attrNames rawScopedCtx);
+      # The path set is bucketed by the SCOPE id, which is built from entity-kind
+      # bindings ONLY (host/user/home). Policy enrichment can later sprinkle
+      # non-entity keys (e.g. `system`) into the resolve ctx; including those here
+      # would desync this lookup's key from the bucket key. Restrict to entity
+      # kinds so the projected id matches `currentScope` regardless of enrichment.
+      scopeId = mkScopeId (lib.getAttrs overrideKinds rawScopedCtx);
+      owner = rawScopedCtx.host or rawScopedCtx.${targetKind} or null;
+      ownerPathSet = if owner != null then owner.__pathSetByScope or { } else { };
+      projected = den.lib.aspects.mkProjectedHasAspect {
+        pathSetByScope = ownerPathSet;
+        inherit scopeId;
+      };
+      scopedCtx = builtins.foldl' (
+        acc: k:
+        acc
+        // {
+          ${k} = acc.${k} // {
+            hasAspect = projected;
+          };
+        }
+      ) rawScopedCtx overrideKinds;
     in
     {
       inherit

--- a/nix/lib/aspects/fx/policy/schema.nix
+++ b/nix/lib/aspects/fx/policy/schema.nix
@@ -54,29 +54,23 @@ let
       rawScopedCtx = enrichedCtx // resolveBindings;
       entityClass = resolveEntityClass targetKind resolveBindings;
 
-      # In-context hasAspect answers PROJECTED membership: what is actually
-      # delivered into THIS scope, not the structural registry tree. The owning
-      # host's production run already bucketed every user scope's path set under
-      # `__pathSetByScope`; a self-scoped entity (no host) uses its own. The
-      # lookup is pure and forced lazily (e.g. at a class-module `mkIf`), so it
-      # never re-enters the resolve that produced the path set. Reading it from an
-      # `includes` position is the one cyclic case (same in-flight run): it forces
-      # the host's own `__resolveResult` and recurses — don't decide includes from
-      # projected membership.
+      # In-context `.hasAspect` answers PROJECTED membership — what's delivered
+      # into this scope (incl. `provides`), not the structural registry tree. The
+      # owning host's production run already bucketed each scope's path set under
+      # `__pathSetByScope`. The lookup is pure and forced lazily (at a class-module
+      # `mkIf`), so it never re-enters the resolve that produced it — except from
+      # an `includes` position, which forces the host's own in-flight
+      # `__resolveResult` and recurses. So: don't decide includes from it.
       #
-      # Only `.hasAspect` is replaced. `mkScopeId` keys off `.name`, so the
-      # derived `ctxNames`/`currentScope` are unperturbed by this wrapping.
+      # Key by entity-kind bindings only: enrichment may add non-entity keys (e.g.
+      # `system`) to the ctx, but buckets are keyed by entity scope — restricting
+      # here keeps the lookup key matched. Only `.hasAspect` is swapped, and
+      # `mkScopeId` keys off `.name`, so the scope ids are otherwise unperturbed.
       overrideKinds = builtins.filter (
         k: schemaEntityKindsSet ? ${k} && builtins.isAttrs (rawScopedCtx.${k} or null)
       ) (builtins.attrNames rawScopedCtx);
-      # The path set is bucketed by the SCOPE id, which is built from entity-kind
-      # bindings ONLY (host/user/home). Policy enrichment can later sprinkle
-      # non-entity keys (e.g. `system`) into the resolve ctx; including those here
-      # would desync this lookup's key from the bucket key. Restrict to entity
-      # kinds so the projected id matches `currentScope` regardless of enrichment.
       scopeId = mkScopeId (lib.getAttrs overrideKinds rawScopedCtx);
-      # The host run buckets every user scope; a self-scoped entity (no host)
-      # uses its own. `or { }` covers an entity without a path set.
+      # Host run buckets every user scope; a host-less entity uses its own.
       ownerPathSet =
         rawScopedCtx.host.__pathSetByScope or rawScopedCtx.${targetKind}.__pathSetByScope or { };
       projected = den.lib.aspects.mkProjectedHasAspect {

--- a/nix/lib/aspects/fx/resolve.nix
+++ b/nix/lib/aspects/fx/resolve.nix
@@ -468,7 +468,9 @@ let
     };
 
   # Full resolution: run pipeline, then assemble output through all phases.
-  fxResolve =
+  # Shared body — returns both `imports` and the per-scope path set so a single
+  # fx.handle backs `resolve` and `resolveWithPaths` (no second pipeline run).
+  fxResolveFull =
     mkPipeline:
     {
       class,
@@ -747,7 +749,16 @@ let
     in
     {
       imports = phase4.${class} or [ ];
+      # Surfaced from the SAME result.state — Task 1 thunked this onto state.
+      pathSetByScope = result.state.pathSetByScope null;
     };
+
+  # Back-compatible projection: imports only. Protects deferredModule consumers
+  # that assert resolve's output is exactly { imports = …; }.
+  fxResolve = mkPipeline: args: { inherit (fxResolveFull mkPipeline args) imports; };
+
+  # imports + per-scope path set, from the SAME fx.handle as fxResolve.
+  fxResolveWithPaths = fxResolveFull;
 
   # Like fxResolve but skips instantiation (phase 4).
   # Returns only class imports from phases 1-3 (wrap, provides, routes).
@@ -805,5 +816,10 @@ let
     };
 in
 {
-  inherit fxResolve fxResolveImports wrapCollectedClasses;
+  inherit
+    fxResolve
+    fxResolveWithPaths
+    fxResolveImports
+    wrapCollectedClasses
+    ;
 }

--- a/nix/lib/aspects/has-aspect.nix
+++ b/nix/lib/aspects/has-aspect.nix
@@ -40,6 +40,21 @@ let
     }:
     (collectPathSet { inherit tree class; }) ? ${refKey ref};
 
+  # Projected hasAspect: pure lookup over an already-computed per-scope path
+  # set (byproduct of the owning entity's production run). No pipeline.
+  # `pathSetByScope`/`scopeId` are read lazily — forced only when the result
+  # boolean is scrutinised (e.g. at a class-module `mkIf`, post-run).
+  mkProjectedHasAspect =
+    { pathSetByScope, scopeId }:
+    let
+      check = ref: (pathSetByScope.${scopeId} or { }) ? ${refKey ref};
+    in
+    {
+      __functor = _: check;
+      forClass = _class: check; # structural set is class-invariant (matches mkEntityHasAspect)
+      forAnyClass = check;
+    };
+
   mkEntityHasAspect =
     {
       tree,
@@ -71,5 +86,6 @@ in
     hasAspectIn
     collectPathSet
     mkEntityHasAspect
+    mkProjectedHasAspect
     ;
 }

--- a/nix/lib/entities/_types.nix
+++ b/nix/lib/entities/_types.nix
@@ -22,18 +22,50 @@ let
     else
       lib.warn "den.aspects.${config.name} not defined — entity gets empty aspect" { };
 
-  # Shared mainModule option — identical across host and home entities.
-  mainModuleOption =
+  # Single shared production run: imports + per-scope path set from ONE fx.handle.
+  # Declared as an option so the module fixpoint memoizes it — every consumer
+  # (mainModule, __pathSetByScope) reads the same value, guaranteeing one resolve.
+  resolveResultOption =
     den: config:
     lib.mkOption {
       internal = true;
       visible = false;
       readOnly = true;
+      type = lib.types.raw;
+      defaultText = "den.lib.aspects.resolveWithPaths config.class config.resolved";
+      default = den.lib.aspects.resolveWithPaths config.class config.resolved;
+    };
+
+  # mainModule now derives imports from the shared result (no second run).
+  mainModuleOption =
+    _den: config:
+    lib.mkOption {
+      internal = true;
+      visible = false;
+      readOnly = true;
       type = lib.types.deferredModule;
-      defaultText = "den.lib.aspects.resolve config.class config.resolved";
-      default = den.lib.aspects.resolve config.class config.resolved;
+      defaultText = "{ inherit (config.__resolveResult) imports; }";
+      default = { inherit (config.__resolveResult) imports; };
+    };
+
+  # Per-scope path set, surfaced for the projected (in-context) hasAspect.
+  pathSetByScopeOption =
+    _den: config:
+    lib.mkOption {
+      internal = true;
+      visible = false;
+      readOnly = true;
+      type = lib.types.raw;
+      defaultText = "config.__resolveResult.pathSetByScope";
+      default = config.__resolveResult.pathSetByScope;
     };
 in
 {
-  inherit strOpt lookupAspect mainModuleOption;
+  inherit
+    strOpt
+    lookupAspect
+    mainModuleOption
+    resolveResultOption
+    pathSetByScopeOption
+    ;
 }

--- a/nix/lib/entities/home.nix
+++ b/nix/lib/entities/home.nix
@@ -6,7 +6,13 @@
   ...
 }@top:
 let
-  inherit (import ./_types.nix { inherit lib; }) strOpt lookupAspect mainModuleOption;
+  inherit (import ./_types.nix { inherit lib; })
+    strOpt
+    lookupAspect
+    mainModuleOption
+    resolveResultOption
+    pathSetByScopeOption
+    ;
 
   homesOption = lib.mkOption {
     description = "den standalone home-manager configurations";
@@ -127,6 +133,8 @@ let
               .${config.class};
           };
           mainModule = mainModuleOption den config;
+          __resolveResult = resolveResultOption den config;
+          __pathSetByScope = pathSetByScopeOption den config;
         };
       }
     );

--- a/nix/lib/entities/host.nix
+++ b/nix/lib/entities/host.nix
@@ -6,7 +6,13 @@
   ...
 }:
 let
-  inherit (import ./_types.nix { inherit lib; }) strOpt lookupAspect mainModuleOption;
+  inherit (import ./_types.nix { inherit lib; })
+    strOpt
+    lookupAspect
+    mainModuleOption
+    resolveResultOption
+    pathSetByScopeOption
+    ;
 
   hostsOption = lib.mkOption {
     description = "den hosts definition";
@@ -106,6 +112,8 @@ let
               .${config.class};
           };
           mainModule = mainModuleOption den config;
+          __resolveResult = resolveResultOption den config;
+          __pathSetByScope = pathSetByScopeOption den config;
         };
       }
     );

--- a/templates/ci/modules/deadbugs/projected-hasaspect.nix
+++ b/templates/ci/modules/deadbugs/projected-hasaspect.nix
@@ -1,0 +1,135 @@
+# In-context `.hasAspect` answers PROJECTED scope membership (what is delivered
+# into the active scope), while the registry query stays structural. One symbol,
+# overloaded by provenance.
+{ denTest, lib, ... }:
+{
+  flake.tests.projected-hasaspect = {
+    test-content-position = denTest (
+      { den, igloo, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+        den.aspects.aspect1.homeManager.programs.atuin.enable = true;
+        den.aspects.aspect2 =
+          {
+            user ? null,
+            ...
+          }:
+          {
+            homeManager.config = lib.mkIf (user != null && user.hasAspect den.aspects.aspect1) {
+              programs.atuin.daemon.enable = true;
+            };
+          };
+        den.aspects.igloo.provides.tux.includes = [
+          den.aspects.aspect1
+          den.aspects.aspect2
+        ];
+        expr = igloo.home-manager.users.tux.programs.atuin.daemon.enable;
+        expected = true;
+      }
+    );
+
+    test-provenance-split = denTest (
+      { den, igloo, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+        den.aspects.aspect1.homeManager.programs.atuin.enable = true;
+        den.aspects.aspect2 =
+          {
+            user ? null,
+            ...
+          }:
+          {
+            homeManager.config = lib.mkIf (user != null && user.hasAspect den.aspects.aspect1) {
+              programs.atuin.daemon.enable = true;
+            };
+          };
+        den.aspects.igloo.provides.tux.includes = [
+          den.aspects.aspect1
+          den.aspects.aspect2
+        ];
+        expr = {
+          registry = den.hosts.x86_64-linux.igloo.users.tux.hasAspect den.aspects.aspect1;
+          inContext = igloo.home-manager.users.tux.programs.atuin.daemon.enable;
+        };
+        expected = {
+          registry = false;
+          inContext = true;
+        };
+      }
+    );
+
+    test-multi-user = denTest (
+      { den, igloo, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users = {
+          tux = { };
+          pingu = { };
+        };
+        den.aspects.aspect1.homeManager.programs.atuin.enable = true;
+        den.aspects.aspect2 =
+          {
+            user ? null,
+            ...
+          }:
+          {
+            homeManager.config = lib.mkIf (user != null && user.hasAspect den.aspects.aspect1) {
+              programs.atuin.daemon.enable = true;
+            };
+          };
+        den.aspects.igloo = {
+          provides.tux.includes = [
+            den.aspects.aspect1
+            den.aspects.aspect2
+          ];
+          provides.pingu.includes = [ den.aspects.aspect2 ];
+        };
+        expr = {
+          tux = igloo.home-manager.users.tux.programs.atuin.daemon.enable or false;
+          pingu = igloo.home-manager.users.pingu.programs.atuin.daemon.enable or false;
+        };
+        expected = {
+          tux = true;
+          pingu = false;
+        };
+      }
+    );
+
+    test-multi-host = denTest (
+      {
+        den,
+        igloo,
+        iceberg,
+        ...
+      }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+        den.hosts.x86_64-linux.iceberg.users.tux = { };
+        den.aspects.aspect1.homeManager.programs.atuin.enable = true;
+        den.aspects.aspect2 =
+          {
+            user ? null,
+            ...
+          }:
+          {
+            homeManager.config = lib.mkIf (user != null && user.hasAspect den.aspects.aspect1) {
+              programs.atuin.daemon.enable = true;
+            };
+          };
+        den.aspects.igloo.provides.tux.includes = [
+          den.aspects.aspect1
+          den.aspects.aspect2
+        ];
+        den.aspects.iceberg.provides.tux.includes = [ den.aspects.aspect2 ];
+        expr = {
+          igloo = igloo.home-manager.users.tux.programs.atuin.daemon.enable or false;
+          iceberg = iceberg.home-manager.users.tux.programs.atuin.daemon.enable or false;
+        };
+        expected = {
+          igloo = true;
+          iceberg = false;
+        };
+      }
+    );
+
+  };
+}

--- a/templates/ci/modules/internal-api/path-set-by-scope.nix
+++ b/templates/ci/modules/internal-api/path-set-by-scope.nix
@@ -47,5 +47,21 @@
         };
       }
     );
+
+    test-entity-exposes-psbs = denTest (
+      { den, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+        den.aspects.aspect1.homeManager.programs.atuin.enable = true;
+        den.aspects.igloo.provides.tux.includes = [ den.aspects.aspect1 ];
+
+        expr =
+          let
+            psbs = den.hosts.x86_64-linux.igloo.__pathSetByScope;
+          in
+          builtins.isAttrs psbs && builtins.any (s: (psbs.${s} or { }) ? "aspect1") (builtins.attrNames psbs);
+        expected = true;
+      }
+    );
   };
 }

--- a/templates/ci/modules/internal-api/path-set-by-scope.nix
+++ b/templates/ci/modules/internal-api/path-set-by-scope.nix
@@ -48,6 +48,36 @@
       }
     );
 
+    test-mkProjectedHasAspect = denTest (
+      { den, ... }:
+      let
+        mk = den.lib.aspects.mkProjectedHasAspect;
+        h = mk {
+          pathSetByScope = {
+            "host=x,user=y" = {
+              "foo" = true;
+            };
+          };
+          scopeId = "host=x,user=y";
+        };
+      in
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+        den.aspects.foo.nixos = { };
+        den.aspects.bar.nixos = { };
+        expr = {
+          hasFoo = h den.aspects.foo;
+          hasBar = h den.aspects.bar;
+          any = h.forAnyClass den.aspects.foo;
+        };
+        expected = {
+          hasFoo = true;
+          hasBar = false;
+          any = true;
+        };
+      }
+    );
+
     test-entity-exposes-psbs = denTest (
       { den, ... }:
       {

--- a/templates/ci/modules/internal-api/path-set-by-scope.nix
+++ b/templates/ci/modules/internal-api/path-set-by-scope.nix
@@ -1,0 +1,28 @@
+# templates/ci/modules/internal-api/path-set-by-scope.nix
+{ denTest, ... }:
+{
+  flake.tests.path-set-by-scope = {
+    test-bucket-by-scope = denTest (
+      { den, ... }:
+      let
+        fxLib = den.lib.aspects.fx;
+        hostRoot = den.lib.resolveEntity "host" { host = den.hosts.x86_64-linux.igloo; };
+        run = fxLib.pipeline.fxFullResolve {
+          class = "nixos";
+          ctx = fxLib.aspect.ctxFromHandlers (hostRoot.__scopeHandlers or { });
+          self = den.lib.aspects.normalizeRoot hostRoot;
+        };
+        psbs = (run.state.pathSetByScope or (_: { })) null;
+        tuxScopes = builtins.filter (s: builtins.match ".*user=tux.*" s != null) (builtins.attrNames psbs);
+      in
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+        den.aspects.aspect1.homeManager.programs.atuin.enable = true;
+        den.aspects.igloo.provides.tux.includes = [ den.aspects.aspect1 ];
+
+        expr = tuxScopes != [ ] && builtins.any (s: (psbs.${s} or { }) ? "aspect1") tuxScopes;
+        expected = true;
+      }
+    );
+  };
+}

--- a/templates/ci/modules/internal-api/path-set-by-scope.nix
+++ b/templates/ci/modules/internal-api/path-set-by-scope.nix
@@ -24,5 +24,28 @@
         expected = true;
       }
     );
+
+    test-resolveWithPaths-shape = denTest (
+      { den, ... }:
+      let
+        hostRoot = den.lib.resolveEntity "host" { host = den.hosts.x86_64-linux.igloo; };
+        r = den.lib.aspects.resolveWithPaths "nixos" hostRoot;
+        plain = den.lib.aspects.resolve "nixos" hostRoot;
+      in
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+        den.aspects.igloo.nixos.networking.hostName = "igloo";
+        expr = {
+          hasImports = r ? imports;
+          hasPaths = r ? pathSetByScope;
+          plainCleanlyImportsOnly = builtins.attrNames plain == [ "imports" ];
+        };
+        expected = {
+          hasImports = true;
+          hasPaths = true;
+          plainCleanlyImportsOnly = true;
+        };
+      }
+    );
   };
 }


### PR DESCRIPTION
## Summary

In-context `.hasAspect` — the `user`/`host` arg inside a parametric aspect body or resolved context — now answers **projected** membership ("is aspectX *delivered into* this scope") instead of the entity's standalone structural tree. This fixes `user.hasAspect <x>` returning `false` for aspects delivered via `provides`, even though the config genuinely applies.

The **registry** query (`den.hosts.….users.tux.hasAspect`) stays the structural query — one symbol, overloaded by provenance:
- entity from a scope-context arg (parametric body / guard) → **projected**
- entity from the registry → **structural** (unchanged)

The projected answer is a **byproduct of the owning host's single existing production run** — **zero extra pipeline runs**. It is also **per active path**: a user appearing under multiple hosts gets per-host answers (`tux@igloo` vs `tux@iceberg`).

## Changes

- `feat(aspects)`: record per-scope `pathSetByScope` in the structural walk (thunked, like `pathSet`)
- `feat(aspects)`: `resolveWithPaths` surfaces `pathSetByScope` from the **same** `fx.handle`; `resolve` return shape unchanged (protects `deferredModule` consumers)
- `feat(entities)`: host/home expose `config.__pathSetByScope` from a shared, memoized `__resolveResult` — a single run backs both `mainModule` and the path set
- `feat(aspects)`: `mkProjectedHasAspect` — a pure per-scope lookup (no pipeline)
- `feat(aspects)`: in-context override in `decomposeSchemaEffect` — wraps entity-kind bindings' `.hasAspect` with the projected lookup, keyed by the active scope id

Cycle-safety rests on two thunk facts: the per-scope set is built in the structural walk (no class-module bodies forced), and `scopedClassImports` is thunked so the trampoline's `deepSeq` never forces a `mkIf` condition mid-run. Deciding an aspect's `includes` from projected membership is the one cyclic case and is documented in `schema.nix` (not supported).

## Test plan

- [x] new internal-api suite `path-set-by-scope` (4): bucketing, `resolveWithPaths` shape, entity exposure, factory
- [x] new deadbug suite `projected-hasaspect` (4): content-position fix, provenance split (`registry=false` / `inContext=true`), multi-user (`tux`/`pingu`), multi-host (`igloo`/`iceberg`)
- [x] `has-aspect` (35/35) and `issue-540-exclude-guard` stay green
- [x] full CI: **874/874 successful**

Diff: 11 files, +386/-11.
