### PR TITLE
fix: sibling policy.when guard dedup collision; spawn subtree routes; multi-def forwarded identity

### DIFF
--- a/nix/lib/aspects/default.nix
+++ b/nix/lib/aspects/default.nix
@@ -124,5 +124,6 @@ in
     isParametricWrapper
     isSubmoduleFn
     isMeaningfulName
+    isSyntheticName
     ;
 }

--- a/nix/lib/aspects/fx/aspect.nix
+++ b/nix/lib/aspects/fx/aspect.nix
@@ -22,6 +22,7 @@ let
   inherit (import ./aspect { inherit lib den; } { inherit ctxFromHandlers; })
     emitIncludes
     emitAspectPolicies
+    chainWrap
     ;
 
   enterScope =
@@ -137,6 +138,7 @@ in
   inherit
     emitIncludes
     emitAspectPolicies
+    chainWrap
     structuralKeysSet
     wrapClassModule
     ctxFromHandlers

--- a/nix/lib/aspects/fx/aspect/children.nix
+++ b/nix/lib/aspects/fx/aspect/children.nix
@@ -19,10 +19,19 @@ let
 
   nameAnon = state: nameIndexed state "<anon>";
 
-  # Synthetic names like "<when>" are shared by every instance of the
-  # constructor that produced them — two sibling guards would otherwise
-  # collide on identity and the gate would silently drop the second.
-  isSyntheticName = name: lib.hasPrefix "<" name && lib.hasSuffix ">" name;
+  # Synthetic names like "<when>" repeat per constructor; index them so
+  # siblings don't dedup-collide at the gate.
+  inherit (den.lib.aspects) isSyntheticName;
+
+  # Wrap a computation in chain-push/chain-pop of the given identity.
+  chainWrap =
+    nodeIdentity: shouldPush: comp:
+    if shouldPush then
+      fx.bind (fx.send "chain-push" { identity = nodeIdentity; }) (
+        _: fx.bind comp (result: fx.bind (fx.send "chain-pop" null) (_: fx.pure result))
+      )
+    else
+      comp;
 
   propagateScope =
     parentScopeHandlers: parentCtxId: child:
@@ -85,9 +94,11 @@ let
         let
           childName = withScope.name or "<anon>";
           child =
-            if !skipNameAnon && !(isMeaningfulName childName) then
+            if skipNameAnon then
+              withScope
+            else if !(isMeaningfulName childName) then
               withScope // { name = nameAnon state idx (withScope.__ctxId or null); }
-            else if !skipNameAnon && isSyntheticName childName then
+            else if isSyntheticName childName then
               withScope // { name = nameIndexed state childName idx (withScope.__ctxId or null); }
             else
               withScope;
@@ -168,5 +179,5 @@ let
     fx.seq (map (c: fx.send "register-constraint" (c // { inherit owner; })) allConstraints);
 in
 {
-  inherit emitIncludes registerConstraints;
+  inherit emitIncludes registerConstraints chainWrap;
 }

--- a/nix/lib/aspects/fx/aspect/children.nix
+++ b/nix/lib/aspects/fx/aspect/children.nix
@@ -8,14 +8,21 @@ let
   inherit (den.lib.aspects.fx) identity;
   inherit (import ./normalize.nix { inherit lib den; }) wrapChild isMeaningfulName;
 
-  nameAnon =
-    state: idx: ctxId:
+  nameIndexed =
+    state: base: idx: ctxId:
     let
       chain = ((state.scopedIncludesChain or (_: { })) null).${state.currentScope} or [ ];
       parent = if chain == [ ] then "<root>" else lib.last chain;
       suffix = if ctxId != null then "/${ctxId}" else "";
     in
-    "${parent}/<anon>:${toString idx}${suffix}";
+    "${parent}/${base}:${toString idx}${suffix}";
+
+  nameAnon = state: nameIndexed state "<anon>";
+
+  # Synthetic names like "<when>" are shared by every instance of the
+  # constructor that produced them — two sibling guards would otherwise
+  # collide on identity and the gate would silently drop the second.
+  isSyntheticName = name: lib.hasPrefix "<" name && lib.hasSuffix ">" name;
 
   propagateScope =
     parentScopeHandlers: parentCtxId: child:
@@ -76,9 +83,12 @@ let
       fx.bind fx.effects.state.get (
         state:
         let
+          childName = withScope.name or "<anon>";
           child =
-            if !skipNameAnon && !(isMeaningfulName (withScope.name or "<anon>")) then
+            if !skipNameAnon && !(isMeaningfulName childName) then
               withScope // { name = nameAnon state idx (withScope.__ctxId or null); }
+            else if !skipNameAnon && isSyntheticName childName then
+              withScope // { name = nameIndexed state childName idx (withScope.__ctxId or null); }
             else
               withScope;
         in

--- a/nix/lib/aspects/fx/aspect/default.nix
+++ b/nix/lib/aspects/fx/aspect/default.nix
@@ -9,6 +9,6 @@ let
   provide = import ./provide.nix { inherit lib den; } { inherit ctxFromHandlers; };
 in
 {
-  inherit (children) emitIncludes registerConstraints;
+  inherit (children) emitIncludes registerConstraints chainWrap;
   inherit (provide) emitAspectPolicies;
 }

--- a/nix/lib/aspects/fx/handlers/check-dedup.nix
+++ b/nix/lib/aspects/fx/handlers/check-dedup.nix
@@ -5,7 +5,7 @@
 }:
 let
   inherit (den.lib.aspects.fx) identity;
-  inherit (den.lib.aspects) isMeaningfulName;
+  inherit (den.lib.aspects) isMeaningfulName isSyntheticName;
 in
 {
   checkDedupHandler = {
@@ -14,9 +14,11 @@ in
       let
         child = param;
         originalName = child.name or "<anon>";
-        isSyntheticName = lib.hasPrefix "<" originalName && lib.hasSuffix ">" originalName;
         rawDedupKey =
-          if isMeaningfulName originalName && !isSyntheticName then identity.key child else null;
+          if isMeaningfulName originalName && !(isSyntheticName originalName) then
+            identity.key child
+          else
+            null;
         scope = state.currentScope or "__unscoped";
         dedupKey = if rawDedupKey != null then "${scope}/${rawDedupKey}" else null;
         seen = (state.includeSeen or (_: { })) null;

--- a/nix/lib/aspects/fx/handlers/compile-conditional.nix
+++ b/nix/lib/aspects/fx/handlers/compile-conditional.nix
@@ -124,6 +124,19 @@ let
     }
     // entityStubs;
 
+  # Emit a passed guard's aspects under the conditional's own identity on
+  # the includes chain, so anonymous payloads from sibling guards get
+  # distinct names instead of colliding at the shared parent.
+  emitGuardedAspects =
+    condNode:
+    fx.bind (fx.send "chain-push" { identity = identity.key condNode; }) (
+      _:
+      fx.bind (emitIncludes {
+        __parentScopeHandlers = condNode.__scopeHandlers or null;
+        __parentCtxId = condNode.__ctxId or null;
+      } condNode.meta.aspects) (results: fx.bind (fx.send "chain-pop" null) (_: fx.pure results))
+    );
+
   # Defer a conditional for re-evaluation at entity boundary.
   deferConditional =
     condNode:
@@ -173,13 +186,7 @@ in
               };
               pass = condNode.meta.guard guardCtx;
             in
-            if pass then
-              emitIncludes {
-                __parentScopeHandlers = condNode.__scopeHandlers or null;
-                __parentCtxId = condNode.__ctxId or null;
-              } condNode.meta.aspects
-            else
-              deferConditional condNode
+            if pass then emitGuardedAspects condNode else deferConditional condNode
           )
         );
         inherit state;
@@ -248,19 +255,14 @@ in
                             fx.bind acc (
                               prev:
                               if pass then
-                                fx.bind
-                                  (emitIncludes {
-                                    __parentScopeHandlers = condNode.__scopeHandlers or null;
-                                    __parentCtxId = condNode.__ctxId or null;
-                                  } condNode.meta.aspects)
-                                  (
-                                    results:
-                                    fx.pure {
-                                      emitted = prev.emitted ++ results;
-                                      failed = prev.failed;
-                                      progressed = true;
-                                    }
-                                  )
+                                fx.bind (emitGuardedAspects condNode) (
+                                  results:
+                                  fx.pure {
+                                    emitted = prev.emitted ++ results;
+                                    failed = prev.failed;
+                                    progressed = true;
+                                  }
+                                )
                               else
                                 fx.pure {
                                   inherit (prev) emitted progressed;

--- a/nix/lib/aspects/fx/handlers/compile-conditional.nix
+++ b/nix/lib/aspects/fx/handlers/compile-conditional.nix
@@ -11,7 +11,7 @@
 let
   inherit (den.lib) fx;
   inherit (den.lib.aspects.fx) identity;
-  inherit (den.lib.aspects.fx.aspect) emitIncludes;
+  inherit (den.lib.aspects.fx.aspect) emitIncludes chainWrap;
   inherit (den.lib.schemaUtil) schemaEntityKindsSet;
   inherit (import ./state-util.nix) scopedAppend;
 
@@ -124,17 +124,15 @@ let
     }
     // entityStubs;
 
-  # Emit a passed guard's aspects under the conditional's own identity on
-  # the includes chain, so anonymous payloads from sibling guards get
-  # distinct names instead of colliding at the shared parent.
+  # Chain-push the conditional around payload emission so sibling guards'
+  # anonymous payloads get distinct names instead of dedup-colliding.
   emitGuardedAspects =
     condNode:
-    fx.bind (fx.send "chain-push" { identity = identity.key condNode; }) (
-      _:
-      fx.bind (emitIncludes {
+    chainWrap (identity.key condNode) true (
+      emitIncludes {
         __parentScopeHandlers = condNode.__scopeHandlers or null;
         __parentCtxId = condNode.__ctxId or null;
-      } condNode.meta.aspects) (results: fx.bind (fx.send "chain-pop" null) (_: fx.pure results))
+      } condNode.meta.aspects
     );
 
   # Defer a conditional for re-evaluation at entity boundary.

--- a/nix/lib/aspects/fx/handlers/resolve-children.nix
+++ b/nix/lib/aspects/fx/handlers/resolve-children.nix
@@ -13,21 +13,13 @@ let
     emitIncludes
     emitAspectPolicies
     registerConstraints
+    chainWrap
     ;
 
   policyMod = import ../policy { inherit lib den; } {
     inherit ctxFromHandlers;
   };
   inherit (policyMod) installPolicies dispatchPoliciesHandler emitPolicyEffectsHandler;
-
-  chainWrap =
-    nodeIdentity: isMeaningful: comp:
-    if isMeaningful then
-      fx.bind (fx.send "chain-push" { identity = nodeIdentity; }) (
-        _: fx.bind comp (result: fx.bind (fx.send "chain-pop" null) (_: fx.pure result))
-      )
-    else
-      comp;
 
   resolveChildSequence =
     aspect:

--- a/nix/lib/aspects/fx/handlers/route.nix
+++ b/nix/lib/aspects/fx/handlers/route.nix
@@ -4,6 +4,15 @@
 let
   inherit (import ./state-util.nix) scopedAppend;
 
+  # Canonical route dedup identity. Shared with the spawn-node merge of
+  # parent-pipeline routes — both sides must key routes identically or
+  # dedup silently diverges.
+  routeKey =
+    fallbackScope: r:
+    "${r.fromClass or "?"}>${r.intoClass or "?"}@${r.sourceScopeId or fallbackScope}/${
+      lib.concatStringsSep "/" (r.path or [ ])
+    }";
+
   registerRouteHandler = {
     "register-route" =
       { param, state }:
@@ -12,11 +21,9 @@ let
         route = param // {
           sourceScopeId = param.sourceScopeId or scope;
         };
-        routeKey = "${route.fromClass or "?"}>${route.intoClass or "?"}@${route.sourceScopeId}/${
-          lib.concatStringsSep "/" (route.path or [ ])
-        }";
+        key = routeKey scope route;
         registeredRoutes = (state.registeredRouteKeys or (_: { })) null;
-        alreadyRegistered = registeredRoutes ? ${routeKey};
+        alreadyRegistered = registeredRoutes ? ${key};
       in
       {
         resume = null;
@@ -26,11 +33,11 @@ let
           else
             scopedAppend state "scopedRoutes" scope route
             // {
-              registeredRouteKeys = _: registeredRoutes // { ${routeKey} = true; };
+              registeredRouteKeys = _: registeredRoutes // { ${key} = true; };
             };
       };
   };
 in
 {
-  inherit registerRouteHandler;
+  inherit registerRouteHandler routeKey;
 }

--- a/nix/lib/aspects/fx/resolve.nix
+++ b/nix/lib/aspects/fx/resolve.nix
@@ -579,6 +579,7 @@ let
           ;
         scopedClassImports = scopedClassImportsRaw;
         scopedPipeEffects = result.state.scopedPipeEffects null;
+        scopedRoutes = result.state.scopedRoutes null;
       };
       # Recursive: a nested complex forward inside a spawned node resolves its
       # source via this SAME threaded primitive (not an isolated pipeline), so
@@ -793,6 +794,7 @@ let
         scopeEntityKind = (result.state.scopeEntityKind or (_: { })) null;
         scopedClassImports = scopedClassImportsRaw;
         scopedPipeEffects = result.state.scopedPipeEffects null;
+        scopedRoutes = result.state.scopedRoutes null;
       };
       # Recursive: see fxResolve above. selfRef is the threaded primitive itself
       # so a nested complex forward inside a spawned node resolves its source via

--- a/nix/lib/aspects/fx/spawn-node.nix
+++ b/nix/lib/aspects/fx/spawn-node.nix
@@ -9,6 +9,7 @@
 { lib, den }:
 let
   inherit (import ./assemble-pipes.nix { inherit lib den; }) assemblePipes;
+  inherit (import ./handlers/route.nix { inherit lib; }) routeKey;
   pipeNamesSet = lib.genAttrs (builtins.attrNames (den.quirks or { })) (_: true);
 in
 {
@@ -114,27 +115,14 @@ in
       # 4. Phases 1-3 over the spawned subtree; class isolation -> one class emitted.
       phase1 = wrapPerScope parentState.ctx augmented mergedClassImports;
       phase2 = applyProvides parentState.ctx augmented (result.state.scopedProvides null) phase1;
-      # Parent-pipeline routes whose source scope lies within the spawned
-      # subtree (e.g. a user-schema `policy.route` registered at this user's
-      # scope in the main pipeline) must apply to the spawned resolution too:
-      # the spawn re-emits the host aspect's class content at those same
-      # scope ids, but the spawned walk does not re-fire schema policies, so
-      # without the parent's routes that content strands in its source class
-      # (a homeLinux->homeManager route never fires and the content drops).
-      #
-      # An aspect-borne route can register in BOTH pipelines at the same
-      # scope (register-route's key dedup is per-pipeline state), so drop
-      # parent entries the spawn already carries: dedupRoutes only collapses
-      # adapterKey routes, and a duplicated path != [] simple route would
-      # re-nest content in fresh keyless wrappers and conflict at the target.
-      # Forwards into the spawned class itself would aggregate classImports
-      # across all merged scopes (including peers); typical forwards target
-      # host classes, which the subtree extraction below discards.
-      routeKey =
-        sid: r:
-        "${r.fromClass or "?"}>${r.intoClass or "?"}@${r.sourceScopeId or sid}/${
-          lib.concatStringsSep "/" (r.path or [ ])
-        }";
+      # Parent-pipeline routes sourced inside the spawned subtree must apply
+      # here too: the spawn re-emits class content at the same scope ids but
+      # never re-fires schema policies, so without them a user-schema route
+      # (homeLinux->homeManager) never fires and the content drops.
+      # Dedup against the spawn's own registrations — an aspect-borne route
+      # can register in both pipelines, and a duplicated path != [] simple
+      # route would re-nest content in fresh keyless wrappers and conflict
+      # at the target.
       spawnRoutes = result.state.scopedRoutes null;
       parentSubtreeRoutes = lib.filterAttrs (sid: _: isInSubtree sid) parentState.scopedRoutes;
       mergedSpawnRoutes =
@@ -142,10 +130,11 @@ in
         // lib.mapAttrs (
           sid: parentRoutes:
           let
-            spawnKeys = lib.genAttrs (map (routeKey sid) (spawnRoutes.${sid} or [ ])) (_: true);
+            spawnHere = spawnRoutes.${sid} or [ ];
+            spawnKeys = lib.genAttrs (map (routeKey sid) spawnHere) (_: true);
             freshParent = builtins.filter (r: !(spawnKeys ? ${routeKey sid r})) parentRoutes;
           in
-          freshParent ++ (spawnRoutes.${sid} or [ ])
+          freshParent ++ spawnHere
         ) parentSubtreeRoutes;
 
       phase3 =

--- a/nix/lib/aspects/fx/spawn-node.nix
+++ b/nix/lib/aspects/fx/spawn-node.nix
@@ -114,9 +114,42 @@ in
       # 4. Phases 1-3 over the spawned subtree; class isolation -> one class emitted.
       phase1 = wrapPerScope parentState.ctx augmented mergedClassImports;
       phase2 = applyProvides parentState.ctx augmented (result.state.scopedProvides null) phase1;
+      # Parent-pipeline routes whose source scope lies within the spawned
+      # subtree (e.g. a user-schema `policy.route` registered at this user's
+      # scope in the main pipeline) must apply to the spawned resolution too:
+      # the spawn re-emits the host aspect's class content at those same
+      # scope ids, but the spawned walk does not re-fire schema policies, so
+      # without the parent's routes that content strands in its source class
+      # (a homeLinux->homeManager route never fires and the content drops).
+      #
+      # An aspect-borne route can register in BOTH pipelines at the same
+      # scope (register-route's key dedup is per-pipeline state), so drop
+      # parent entries the spawn already carries: dedupRoutes only collapses
+      # adapterKey routes, and a duplicated path != [] simple route would
+      # re-nest content in fresh keyless wrappers and conflict at the target.
+      # Forwards into the spawned class itself would aggregate classImports
+      # across all merged scopes (including peers); typical forwards target
+      # host classes, which the subtree extraction below discards.
+      routeKey =
+        sid: r:
+        "${r.fromClass or "?"}>${r.intoClass or "?"}@${r.sourceScopeId or sid}/${
+          lib.concatStringsSep "/" (r.path or [ ])
+        }";
+      spawnRoutes = result.state.scopedRoutes null;
+      parentSubtreeRoutes = lib.filterAttrs (sid: _: isInSubtree sid) parentState.scopedRoutes;
+      mergedSpawnRoutes =
+        spawnRoutes
+        // lib.mapAttrs (
+          sid: parentRoutes:
+          let
+            spawnKeys = lib.genAttrs (map (routeKey sid) (spawnRoutes.${sid} or [ ])) (_: true);
+            freshParent = builtins.filter (r: !(spawnKeys ? ${routeKey sid r})) parentRoutes;
+          in
+          freshParent ++ (spawnRoutes.${sid} or [ ])
+        ) parentSubtreeRoutes;
+
       phase3 =
-        applyRoutes selfRef parentState.ctx augmented spawnRoot mergedScopeParent
-          (result.state.scopedRoutes null)
+        applyRoutes selfRef parentState.ctx augmented spawnRoot mergedScopeParent mergedSpawnRoutes
           phase2;
 
       # Restrict extraction to the spawned subtree (spawnRoot + descendants).

--- a/nix/lib/aspects/types.nix
+++ b/nix/lib/aspects/types.nix
@@ -25,6 +25,11 @@ let
   isMeaningfulName =
     name: name != "<anon>" && name != "<function body>" && !(lib.hasPrefix "[definition " name);
 
+  # Constructor-stamped names like "<when>" repeat across instances; the
+  # child walk indexes them and the gate never keys dedup on them. Both
+  # sites must share this predicate or naming and dedup silently desync.
+  isSyntheticName = name: lib.hasPrefix "<" name && lib.hasSuffix ">" name;
+
   aspectType =
     typeCfg:
     let
@@ -484,25 +489,23 @@ let
                           bv
                       ) b;
                     subForwarded = builtins.foldl' deepMerge { } subAttrVals;
-                    # Annotate forwarded children (recursively) with __provider
-                    # so navigation through a multi-def key yields identifiable
-                    # aspects. Without this, apps.dev.security.gpg arrives raw
-                    # (no name, no __provider), children.nix renames it to
-                    # <parent>/<anon>:<idx>, and the same aspect included via
-                    # two paths gets two identities — emit-class dedup fails
-                    # and class content double-applies (equal-priority option
-                    # conflicts). The single-def path tags children via
-                    # annotatedMerged; this is its multi-def counterpart.
-                    # Name-based guards come first so registered class/pipe/
-                    # structural values are never forced mid-merge — forcing a
-                    # class value that reads the flake's own outputs re-enters
-                    # the flake fixpoint (#580; see isNestedKey). Only
-                    # unregistered namespace keys (which navigation must force
-                    # anyway) get WHNF'd by the isAttrs check.
+                    # Multi-def counterpart of annotatedMerged: tag forwarded
+                    # children recursively with __provider, else navigation
+                    # through a multi-def key yields raw children that get
+                    # anon-renamed per inclusion path and double-emit class
+                    # content. Recursive (unlike annotatedMerged) because
+                    # subForwarded never re-enters aspectContentType per
+                    # level. Name-based guards come first — forcing a
+                    # registered class value mid-merge can re-enter the flake
+                    # fixpoint (#580; see isNestedKey); only unregistered
+                    # namespace keys (forced by navigation anyway) get WHNF'd.
                     annotateDeep =
                       provPath: attrs:
                       lib.mapAttrs (
                         ck: cv:
+                        let
+                          childPath = provPath ++ [ ck ];
+                        in
                         if
                           !(lib.hasPrefix "__" ck)
                           && !(classReg ? ${ck})
@@ -512,24 +515,19 @@ let
                           && !(cv ? __provider)
                           && !(cv ? __contentValues)
                         then
-                          annotateDeep (provPath ++ [ ck ]) cv // { __provider = provPath ++ [ ck ]; }
+                          annotateDeep childPath cv // { __provider = childPath; }
                         else
                           cv
                       ) attrs;
-                  in
-                  annotateDeep (
-                    (typeCfg.providerPrefix or [ ])
-                    ++ [
-                      keyName
-                      k
-                    ]
-                  ) subForwarded
-                  // {
-                    __contentValues = defsForKey;
-                    __provider = (typeCfg.providerPrefix or [ ]) ++ [
+                    provBase = (typeCfg.providerPrefix or [ ]) ++ [
                       keyName
                       k
                     ];
+                  in
+                  annotateDeep provBase subForwarded
+                  // {
+                    __contentValues = defsForKey;
+                    __provider = provBase;
                   }
               );
           # Single-function content wrappers need __functor so the wrapper is
@@ -747,5 +745,6 @@ in
     isParametricWrapper
     isSubmoduleFn
     isMeaningfulName
+    isSyntheticName
     ;
 }

--- a/nix/lib/aspects/types.nix
+++ b/nix/lib/aspects/types.nix
@@ -484,8 +484,46 @@ let
                           bv
                       ) b;
                     subForwarded = builtins.foldl' deepMerge { } subAttrVals;
+                    # Annotate forwarded children (recursively) with __provider
+                    # so navigation through a multi-def key yields identifiable
+                    # aspects. Without this, apps.dev.security.gpg arrives raw
+                    # (no name, no __provider), children.nix renames it to
+                    # <parent>/<anon>:<idx>, and the same aspect included via
+                    # two paths gets two identities — emit-class dedup fails
+                    # and class content double-applies (equal-priority option
+                    # conflicts). The single-def path tags children via
+                    # annotatedMerged; this is its multi-def counterpart.
+                    # Name-based guards come first so registered class/pipe/
+                    # structural values are never forced mid-merge — forcing a
+                    # class value that reads the flake's own outputs re-enters
+                    # the flake fixpoint (#580; see isNestedKey). Only
+                    # unregistered namespace keys (which navigation must force
+                    # anyway) get WHNF'd by the isAttrs check.
+                    annotateDeep =
+                      provPath: attrs:
+                      lib.mapAttrs (
+                        ck: cv:
+                        if
+                          !(lib.hasPrefix "__" ck)
+                          && !(classReg ? ${ck})
+                          && !(pipeReg ? ${ck})
+                          && !(structuralKeysSet ? ${ck})
+                          && builtins.isAttrs cv
+                          && !(cv ? __provider)
+                          && !(cv ? __contentValues)
+                        then
+                          annotateDeep (provPath ++ [ ck ]) cv // { __provider = provPath ++ [ ck ]; }
+                        else
+                          cv
+                      ) attrs;
                   in
-                  subForwarded
+                  annotateDeep (
+                    (typeCfg.providerPrefix or [ ])
+                    ++ [
+                      keyName
+                      k
+                    ]
+                  ) subForwarded
                   // {
                     __contentValues = defsForKey;
                     __provider = (typeCfg.providerPrefix or [ ]) ++ [

--- a/templates/ci/modules/deadbugs/multi-def-namespace-identity.nix
+++ b/templates/ci/modules/deadbugs/multi-def-namespace-identity.nix
@@ -1,0 +1,103 @@
+# Regression: navigating through a MULTI-DEF nested namespace key strips
+# aspect identity from its children.
+#
+# aspectContentType's multi-def branch returns `subForwarded // { __provider;
+# __contentValues; }` — the colliding key itself is tagged, but its forwarded
+# children are raw attrsets with no `name` and no `__provider`. wrapChild then
+# falls through nameless and children.nix renames the child to
+# `<parent>/<anon>:<idx>`, so the same aspect included via two paths gets two
+# identities: emit-class dedup fails and the class content double-applies
+# (equal-priority option conflicts for scalar options, duplicated entries for
+# list options) when the content re-emits in a spawned user resolution.
+#
+# Real-world shape: gpg.nix and ssh.nix both define children of
+# den.aspects.apps.dev.security (multi-def at `dev`), and
+# apps.dev.security.gpg is included by both roles.dev and roles.dev-gui —
+# pinentry.package then gets two equal-priority definitions in the user's
+# home-manager config.
+#
+# The single-def path is unaffected (annotatedMerged tags those children),
+# which is why 3-level aspects like apps.shell.foo dedup fine.
+{ denTest, ... }:
+{
+  flake.tests.multi-def-namespace-identity = {
+
+    # Aspect under a multi-def key, included via two roles → its homeManager
+    # content must reach the user's HM config exactly once.
+    test-multi-def-child-dedups-across-two-includes = denTest (
+      {
+        den,
+        lib,
+        tuxHm,
+        ...
+      }:
+      {
+        imports = [
+          # Two "files" each contribute a child of apps.dev.security →
+          # multi-def collision at `dev` (and `security`).
+          {
+            # `host` makes the block context-dependent (resolved per node),
+            # matching real aspects — a plain attrset would dedup by value
+            # equality and mask the identity bug.
+            den.aspects.apps.dev.security.gpg.homeManager =
+              { host, ... }:
+              {
+                home.sessionPath = [ "/dummy-gpg" ];
+              };
+          }
+          { den.aspects.apps.dev.security.ssh.homeManager.programs.vim.enable = true; }
+        ];
+
+        den.aspects.roles.r1.includes = [ den.aspects.apps.dev.security.gpg ];
+        den.aspects.roles.r2.includes = [ den.aspects.apps.dev.security.gpg ];
+
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+        den.aspects.igloo.includes = [
+          den.aspects.roles.r1
+          den.aspects.roles.r2
+        ];
+        den.aspects.tux.includes = [ den._.host-aspects ];
+
+        expr = builtins.length (lib.filter (p: p == "/dummy-gpg") tuxHm.home.sessionPath);
+        expected = 1;
+      }
+    );
+
+    # Same, two levels deeper — the annotation must recurse, not just tag the
+    # first forwarded level.
+    test-deep-multi-def-child-dedups = denTest (
+      {
+        den,
+        lib,
+        tuxHm,
+        ...
+      }:
+      {
+        imports = [
+          {
+            den.aspects.svc.net.mesh.core.agent.homeManager =
+              { host, ... }:
+              {
+                home.sessionPath = [ "/dummy-agent" ];
+              };
+          }
+          { den.aspects.svc.net.mesh.edge.proxy.homeManager.programs.vim.enable = true; }
+        ];
+
+        den.aspects.roles.r1.includes = [ den.aspects.svc.net.mesh.core.agent ];
+        den.aspects.roles.r2.includes = [ den.aspects.svc.net.mesh.core.agent ];
+
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+        den.aspects.igloo.includes = [
+          den.aspects.roles.r1
+          den.aspects.roles.r2
+        ];
+        den.aspects.tux.includes = [ den._.host-aspects ];
+
+        expr = builtins.length (lib.filter (p: p == "/dummy-agent") tuxHm.home.sessionPath);
+        expected = 1;
+      }
+    );
+
+  };
+}

--- a/templates/ci/modules/deadbugs/route-platform-class-host-aspect.nix
+++ b/templates/ci/modules/deadbugs/route-platform-class-host-aspect.nix
@@ -1,0 +1,108 @@
+# Regression: a `policy.route` (fromClass=homeLinux, intoClass=homeManager)
+# registered via `den.schema.user.includes` never delivers content from
+# HOST-attached aspects.
+#
+# A user's homeManager content resolves via spawnNode
+# (resolve-at-emitting-node): the spawned walk re-emits the host aspect's
+# class content at the spawned scopes, but it neither fires the user-schema
+# route policies nor inherits the parent pipeline's registered routes. The
+# homeLinux content is emitted (visible in the spawned per-scope partition)
+# yet never routed into the collected class (homeManager) — it silently
+# drops. The same aspect's homeManager block delivers fine, masking the gap.
+#
+# Real-world shape: nix-config's home-platform.nix routes
+# homeLinux/homeDarwin → homeManager per host platform; gpg's pinentry
+# moved into homeLinux and vanished from every generation.
+{ denTest, ... }:
+{
+  flake.tests.route-platform-class-host-aspect = {
+
+    # Control: the same route delivers user-attached homeLinux content.
+    test-user-attached-homelinux-routes = denTest (
+      {
+        den,
+        lib,
+        tuxHm,
+        ...
+      }:
+      {
+        den.classes.homeLinux.description = "Home-manager modules for Linux hosts";
+
+        den.policies.homeLinux-to-hm =
+          { host, ... }:
+          lib.optional (lib.hasSuffix "-linux" host.system) (
+            den.lib.policy.route {
+              fromClass = "homeLinux";
+              intoClass = "homeManager";
+              path = [ ];
+            }
+          );
+        den.schema.user.includes = [ den.policies.homeLinux-to-hm ];
+
+        den.aspects.shell-tools = {
+          homeManager.programs.vim.enable = true;
+          homeLinux.programs.git.enable = true;
+        };
+
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+        den.aspects.igloo.tux.includes = [ den.aspects.shell-tools ];
+
+        expr = {
+          vim = tuxHm.programs.vim.enable;
+          git = tuxHm.programs.git.enable;
+        };
+        expected = {
+          vim = true;
+          git = true;
+        };
+      }
+    );
+
+    # Host-attached aspect: the homeManager block reaches the user's HM
+    # config (via spawnNode), so the homeLinux block routed into homeManager
+    # must reach it too.
+    test-host-attached-homelinux-routes = denTest (
+      {
+        den,
+        lib,
+        tuxHm,
+        ...
+      }:
+      {
+        den.classes.homeLinux.description = "Home-manager modules for Linux hosts";
+
+        den.policies.homeLinux-to-hm =
+          { host, ... }:
+          lib.optional (lib.hasSuffix "-linux" host.system) (
+            den.lib.policy.route {
+              fromClass = "homeLinux";
+              intoClass = "homeManager";
+              path = [ ];
+            }
+          );
+        den.schema.user.includes = [ den.policies.homeLinux-to-hm ];
+
+        den.aspects.desk-role = {
+          homeManager.programs.vim.enable = true;
+          homeLinux.programs.git.enable = true;
+        };
+
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+        den.aspects.igloo.includes = [ den.aspects.desk-role ];
+        # Project host aspects onto the user's homeManager (the standard
+        # opt-in; cortex/sini uses the same battery).
+        den.aspects.tux.includes = [ den._.host-aspects ];
+
+        expr = {
+          vim = tuxHm.programs.vim.enable;
+          git = tuxHm.programs.git.enable;
+        };
+        expected = {
+          vim = true;
+          git = true;
+        };
+      }
+    );
+
+  };
+}

--- a/templates/ci/modules/features/deadbugs/policy-when-hasaspect-pair.nix
+++ b/templates/ci/modules/features/deadbugs/policy-when-hasaspect-pair.nix
@@ -1,0 +1,56 @@
+# Two policy.when guards on hasAspect in one aspect: both should fire.
+{ denTest, ... }:
+{
+  flake.tests.deadbugs.policy-when-hasaspect-pair = {
+
+    test-both-guards-fire = denTest (
+      { den, tuxHm, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.aspect1 = {
+          homeManager.programs.atuin.enable = true;
+        };
+
+        den.aspects.aspect2 = {
+          homeManager.programs.atuin.daemon.enable = true;
+        };
+
+        den.aspects.aspect3 =
+          let
+            aspect1Policy = den.lib.policy.when ({ user, ... }: user.hasAspect den.aspects.aspect1) {
+              homeManager.programs.atuin.settings.foo = "bar";
+            };
+
+            aspect2Policy = den.lib.policy.when ({ user, ... }: user.hasAspect den.aspects.aspect2) {
+              homeManager.programs.atuin.settings.bar = "baz";
+            };
+          in
+          {
+            includes = [
+              aspect1Policy
+              aspect2Policy
+            ];
+          };
+
+        den.aspects.tux = {
+          includes = [
+            den.aspects.aspect1
+            den.aspects.aspect2
+            den.aspects.aspect3
+          ];
+        };
+
+        expr = {
+          foo = tuxHm.programs.atuin.settings.foo or null;
+          bar = tuxHm.programs.atuin.settings.bar or null;
+        };
+        expected = {
+          foo = "bar";
+          bar = "baz";
+        };
+      }
+    );
+
+  };
+}


### PR DESCRIPTION
Three pipeline fixes plus a shared-helper cleanup, each fix with a deadbugs regression test. Full CI: 879/879.

## fix: sibling `policy.when` guards no longer collide at the dedup gate

Two `policy.when` includes in the same aspect both compile to conditional aspects named `<when>`, and `compile-conditional` emitted passing payloads without joining the includes chain. Both anonymous payloads resolved to the same identity (`<parent>/<anon>:0`), so the gate's dedup silently dropped the second guard's content — first guard's settings landed, second's vanished.

Fix is two coordinated changes:
- `children.nix`: synthetic-named children (`<...>`) now get indexed names like anonymous children do (`aspect3/<when>:0`, `aspect3/<when>:1`).
- `compile-conditional.nix`: payload emission chain-pushes the conditional's identity (immediate and drain paths), so payloads nest under their guard (`aspect3/<when>:0/<anon>:0`) instead of colliding at the shared parent. Side benefit: constraint `ownerChain` now attributes guard-emitted aspects to their conditional.

## fix(spawn): apply parent subtree routes in spawned resolution

A `policy.route` registered at a user scope in the main pipeline (e.g. homeLinux→homeManager from `den.schema.user.includes`) never applied to the spawned per-user resolution: the spawn re-emits host-aspect class content at the same scope ids but only applied its own walk's routes, stranding routed-class content in its source class. Thread the parent pipeline's `scopedRoutes` into the spawn and apply the subtree-relevant ones in phase3, deduping against the spawn's own registrations.

## fix(types): tag multi-def forwarded children with `__provider`

`aspectContentType`'s multi-def branch forwarded colliding-key children raw — no name, no `__provider` — so a navigated aspect under a multi-def namespace lost its identity and was renamed `<parent>/<anon>:<idx>` per inclusion path. The same aspect included via two roles then double-emitted, producing equal-priority option conflicts in home-manager. Annotate forwarded children recursively, mirroring the single-def path.

## refactor: share one-definition helpers

Post-review cleanup of duplication the fixes introduced or exposed — no behavior change:
- `isSyntheticName` hoisted next to `isMeaningfulName` and shared by child naming and gate dedup (the two sites must agree or naming and dedup silently desync).
- `chainWrap` moved into the aspect module; `resolve-children` and `compile-conditional` both use it.
- Canonical `routeKey` lives in the register-route handler; the spawn-node merge imports it instead of duplicating the formula.
- Repeated provider-path / spawn-route expressions bound once; comments tightened.

## Tests

- `deadbugs/policy-when-hasaspect-pair.nix` — both sibling guards' settings land
- `deadbugs/route-platform-class-host-aspect.nix` — user-scope route applies in spawned resolution
- `deadbugs/multi-def-namespace-identity.nix` — multi-def namespace child keeps identity, no double emission

All three tests verified to fail on main and pass on this branch.