### PR TITLE
feat: synthesize host identity for standalone user@host homes

### DIFF
--- a/modules/aspects/batteries/flake-parts/inputs.nix
+++ b/modules/aspects/batteries/flake-parts/inputs.nix
@@ -39,7 +39,9 @@ let
     {
       name = "inputs'/os";
     }
-    // mkAspect host.class host.system;
+    # Guard a synthetic host identity (classless `user@host` home) the same way
+    # hmAspect already guards `home ? class`.
+    // lib.optionalAttrs (host ? class) (mkAspect host.class host.system);
 
   userAspect =
     {

--- a/modules/aspects/batteries/flake-parts/self.nix
+++ b/modules/aspects/batteries/flake-parts/self.nix
@@ -39,7 +39,9 @@ let
     {
       name = "self'/os";
     }
-    // mkAspect host.class host.system;
+    # Guard a synthetic host identity (classless `user@host` home) the same way
+    # homeAspect already guards `home ? class`.
+    // lib.optionalAttrs (host ? class) (mkAspect host.class host.system);
 
   userAspect =
     {

--- a/modules/aspects/batteries/hostname.nix
+++ b/modules/aspects/batteries/hostname.nix
@@ -1,4 +1,4 @@
-{ ... }:
+{ lib, ... }:
 let
   description = ''
     Sets the system hostname as defined in `den.hosts.<name>.hostName`:
@@ -14,6 +14,10 @@ let
     { host, ... }:
     {
       name = "hostname/os";
+    }
+    # A synthetic host identity (a `user@host` home with no declared host) has
+    # no OS class to set a hostname on; gate to real, class-bearing hosts.
+    // lib.optionalAttrs (host ? class) {
       ${host.class}.networking.hostName = host.hostName;
     };
 in

--- a/modules/aspects/batteries/insecure/insecure-predicate-builder.nix
+++ b/modules/aspects/batteries/insecure/insecure-predicate-builder.nix
@@ -31,6 +31,11 @@ let
     { host }:
     {
       name = "insecure-predicate/os";
+    }
+    # A synthetic host identity (from a `user@host` home with no declared host)
+    # has no class output, so there is nothing to import into. Guard like
+    # homeAspect already does.
+    // lib.optionalAttrs (host ? class) {
       ${host.class}.imports = [ insecureModule ];
     };
 

--- a/modules/aspects/batteries/os-class.nix
+++ b/modules/aspects/batteries/os-class.nix
@@ -25,11 +25,16 @@ in
 
   den.policies.os-to-host =
     { host, ... }:
+    # A synthetic host identity (a `user@host` home with no declared host) has
+    # no OS class to route into; `host ? class` gates OS routing to real hosts.
     lib.optional
-      (builtins.elem host.class [
-        "nixos"
-        "darwin"
-      ])
+      (
+        host ? class
+        && builtins.elem host.class [
+          "nixos"
+          "darwin"
+        ]
+      )
       (
         den.lib.policy.route {
           fromClass = "os";

--- a/modules/aspects/batteries/unfree/unfree-predicate-builder.nix
+++ b/modules/aspects/batteries/unfree/unfree-predicate-builder.nix
@@ -31,6 +31,11 @@ let
     { host }:
     {
       name = "unfree-predicate/os";
+    }
+    # A synthetic host identity (from a `user@host` home with no declared host)
+    # has no class output, so there is nothing to import into. Guard like
+    # homeAspect already does.
+    // lib.optionalAttrs (host ? class) {
       ${host.class}.imports = [ unfreeModule ];
     };
 

--- a/nix/lib/aspects/fx/aspect.nix
+++ b/nix/lib/aspects/fx/aspect.nix
@@ -69,6 +69,26 @@ let
           __fn = resolved;
           __args = lib.functionArgs resolved;
         }
+    else if builtins.isList resolved then
+      # A parametric/conditional include may return a list of effects, e.g.
+      # `({ host, ... }: lib.optional cond (policy.include {...}))`. Normalize
+      # each entry into an include the re-resolve will walk: include-effect
+      # descriptors contribute their `.value`; bare aspects pass through. Other
+      # effect kinds can't be expressed as a parametric merge here.
+      let
+        toInclude =
+          e:
+          if builtins.isAttrs e && (e.__policyEffect or null) == "include" then
+            e.value
+          else if builtins.isAttrs e && e ? __policyEffect then
+            throw "den: includes function at '${aspect.name or "<anon>"}' returned a '${e.__policyEffect}' effect in a list; only include effects (or bare aspects) are supported here"
+          else
+            e;
+        # Flatten nested lists (e.g. `[ (lib.optional …) … ]`) so every effect is
+        # reached rather than silently dropped as an unwalked includes entry.
+        entries = builtins.filter (e: e != null) (lib.flatten resolved);
+      in
+      base // { includes = (base.includes or [ ]) ++ map toInclude entries; }
     else
       base // builtins.removeAttrs resolved [ "meta" ];
 

--- a/nix/lib/aspects/fx/aspect/provide.nix
+++ b/nix/lib/aspects/fx/aspect/provide.nix
@@ -28,11 +28,25 @@ let
           )
         else
           (
-            { host, user, ... }:
+            # Deliver to a user or home scope matching `key` by host- or
+            # user-name. All entity args are optional so this fires at every
+            # sibling kind (user AND home) — leaving any required entity arg
+            # would restrict late-dispatch to that kind only, missing standalone
+            # homes. `atDeliverableScope` keeps it inert at a bare host scope
+            # (which fans out to its user scopes), and lets a standalone
+            # `user@host` home match on its synthetic host identity.
+            {
+              host ? null,
+              user ? null,
+              home ? null,
+              ...
+            }:
             let
               result = applyProvide value { inherit host user; };
+              atDeliverableScope = user != null || home != null;
+              matches = (host != null && host.name == key) || (user != null && user.name == key);
             in
-            lib.optionals (host.name == key || user.name == key) [
+            lib.optionals (atDeliverableScope && matches) [
               (policy.include result)
             ]
           );

--- a/nix/lib/entities/home.nix
+++ b/nix/lib/entities/home.nix
@@ -39,6 +39,27 @@ let
         hostByName = if hostName != null then den.hosts.${system}.${hostName} or null else null;
         userByName = if hostByName != null then hostByName.users.${userName} or null else null;
 
+        # A home named `user@host` carries a host identity even when that host
+        # isn't declared in `den.hosts`. Synthesize a minimal `{ name = ...; }`
+        # so host-keyed provides/policies (which match on `host.name`) resolve
+        # for an otherwise-standalone home — without instantiating a real host
+        # entity, which would pull in its platform builder (e.g. nix-darwin).
+        # A declared host always wins and remains the only thing that wires
+        # `osConfig`.
+        #
+        # Only `host` is synthesized, never `user`: a synthetic host alone fires
+        # `{ host }`-keyed policies (gated on `host ? class` so OS-class routing
+        # stays inert for a classless synthetic host), while `{ host, user }`-keyed
+        # OS batteries (define-user, user-to-host, …) keep their existing
+        # null-user gating and fall back to their home-scope path.
+        hostCtx =
+          if hostByName != null then
+            hostByName
+          else if nameWithHost then
+            { name = hostName; }
+          else
+            null;
+
         homeManagerConfiguration =
           if nameWithHost && hostByName != null then
             { pkgs, modules }:
@@ -55,7 +76,7 @@ let
         freeformType = lib.types.attrsOf lib.types.anything;
         imports = [ den.schema.home ];
         config._module.args.home = config;
-        config._module.args.host = hostByName;
+        config._module.args.host = hostCtx;
         config._module.args.user = userByName;
         options = {
           name = strOpt "home configuration name" userName;
@@ -70,7 +91,7 @@ let
             defaultText = lib.literalExpression "user";
           };
           host = lib.mkOption {
-            default = hostByName;
+            default = hostCtx;
             defaultText = lib.literalExpression "host";
           };
           system = strOpt "platform system" system;

--- a/templates/ci/modules/deadbugs/standalone-home-host-context.nix
+++ b/templates/ci/modules/deadbugs/standalone-home-host-context.nix
@@ -1,0 +1,280 @@
+# Host-conditional config in a standalone home resolves when the home is named
+# `user@host`. A declared host is used directly; an undeclared host yields a
+# synthetic `{ name = host; }` identity (home.nix) so host-name-keyed policies
+# and `provides.<host>` resolve without instantiating a real host (no platform
+# builder like nix-darwin). A plain (no `@host`) home has no host context, so
+# host-keyed effects stay inert there.
+#
+# Mostly uses a linux/nixos host to exercise the (class-agnostic) host-context
+# mechanism; one darwin test proves no nix-darwin instantiation is needed.
+{ denTest, ... }:
+{
+  flake.tests.deadbugs.standalone-home-host-context = {
+
+    # Unbound standalone home: `host` absent from ctx → host policy never fires.
+    test-unbound-home-host-policy-does-not-fire = denTest (
+      { config, den, ... }:
+      {
+        den.homes.x86_64-linux.ben = { };
+
+        den.aspects.ben.homeManager.home = {
+          username = "ben";
+          homeDirectory = "/home/ben";
+        };
+        den.aspects.ben.includes = [
+          (den.lib.policy.when ({ host, ... }: host.name == "homehost") (
+            _: den.lib.policy.include { homeManager.programs.zsh.profileExtra = "brew"; }
+          ))
+        ];
+
+        expr = config.flake.homeConfigurations.ben.config.programs.zsh.profileExtra;
+        expected = "";
+      }
+    );
+
+    # `user@host` naming WITHOUT declaring the host: home.nix synthesizes a
+    # minimal `{ name = "homehost"; }` host identity from the name, so the
+    # host-keyed policy fires — no `den.hosts` entry (and no host instantiation)
+    # required. This is what lets a standalone home select host config without
+    # importing the host's platform builder (nix-darwin, etc.).
+    test-at-host-naming-synthesizes-host-and-fires = denTest (
+      { config, den, ... }:
+      {
+        den.homes.x86_64-linux."ben@homehost" = { };
+
+        den.aspects.ben.homeManager.home = {
+          username = "ben";
+          homeDirectory = "/home/ben";
+        };
+        den.aspects.ben.includes = [
+          (den.lib.policy.when ({ host, ... }: host.name == "homehost") (
+            _: den.lib.policy.include { homeManager.programs.zsh.profileExtra = "brew"; }
+          ))
+        ];
+
+        expr = config.flake.homeConfigurations."ben@homehost".config.programs.zsh.profileExtra;
+        expected = "brew";
+      }
+    );
+
+    # Bound home (`user@host`, host declared): `host` enters ctx → policy fires.
+    test-bound-home-when-policy-fires = denTest (
+      { config, den, ... }:
+      {
+        den.hosts.x86_64-linux.homehost.users.ben = { };
+        den.homes.x86_64-linux."ben@homehost" = { };
+
+        den.aspects.ben.homeManager.home = {
+          username = "ben";
+          homeDirectory = "/home/ben";
+        };
+        den.aspects.ben.includes = [
+          (den.lib.policy.when ({ host, ... }: host.name == "homehost") (
+            _: den.lib.policy.include { homeManager.programs.zsh.profileExtra = "brew"; }
+          ))
+        ];
+
+        expr = config.flake.homeConfigurations."ben@homehost".config.programs.zsh.profileExtra;
+        expected = "brew";
+      }
+    );
+
+    # Bound home, raw-function include returning a list of effects
+    # (`lib.optional cond (policy.include {...})`). The parametric path now
+    # normalizes a list return into includes instead of throwing
+    # "expected a set but found a list".
+    test-bound-home-list-returning-include-fires = denTest (
+      {
+        config,
+        den,
+        lib,
+        ...
+      }:
+      {
+        den.hosts.x86_64-linux.homehost.users.ben = { };
+        den.homes.x86_64-linux."ben@homehost" = { };
+
+        den.aspects.ben.homeManager.home = {
+          username = "ben";
+          homeDirectory = "/home/ben";
+        };
+        den.aspects.ben.includes = [
+          (
+            { host, ... }:
+            lib.optional (host.name == "homehost") (
+              den.lib.policy.include { homeManager.programs.zsh.profileExtra = "brew"; }
+            )
+          )
+        ];
+
+        expr = config.flake.homeConfigurations."ben@homehost".config.programs.zsh.profileExtra;
+        expected = "brew";
+      }
+    );
+
+    # A list-returning include with multiple include effects applies all of them.
+    test-bound-home-multi-include-list-applies-all = denTest (
+      {
+        config,
+        den,
+        ...
+      }:
+      {
+        den.hosts.x86_64-linux.homehost.users.ben = { };
+        den.homes.x86_64-linux."ben@homehost" = { };
+
+        den.aspects.ben.homeManager.home = {
+          username = "ben";
+          homeDirectory = "/home/ben";
+        };
+        den.aspects.ben.includes = [
+          (
+            { host, ... }:
+            [
+              (den.lib.policy.include { homeManager.programs.zsh.profileExtra = "from-profile"; })
+              (den.lib.policy.include { homeManager.programs.zsh.initExtra = "from-init"; })
+            ]
+          )
+        ];
+
+        expr = {
+          profile = config.flake.homeConfigurations."ben@homehost".config.programs.zsh.profileExtra;
+          init = config.flake.homeConfigurations."ben@homehost".config.programs.zsh.initExtra;
+        };
+        expected = {
+          profile = "from-profile";
+          init = "from-init";
+        };
+      }
+    );
+
+    # A list-returning include carrying a non-include effect (here `exclude`)
+    # can't be expressed as a parametric include merge — clear `den:` error.
+    test-bound-home-list-with-non-include-effect-throws = denTest (
+      {
+        config,
+        den,
+        ...
+      }:
+      {
+        den.hosts.x86_64-linux.homehost.users.ben = { };
+        den.homes.x86_64-linux."ben@homehost" = { };
+
+        den.aspects.ben.homeManager.home = {
+          username = "ben";
+          homeDirectory = "/home/ben";
+        };
+        den.aspects.ben.includes = [
+          ({ host, ... }: [ (den.lib.policy.exclude { homeManager.programs.zsh.enable = true; }) ])
+        ];
+
+        expectedError = {
+          type = "ThrownError";
+          msg = "returned a 'exclude' effect in a list";
+        };
+        expr = config.flake.homeConfigurations."ben@homehost".config.home.username;
+      }
+    );
+
+    # Bound home, `provides.<hostname>` cross-delivery form also fires.
+    test-bound-home-provides-form-fires = denTest (
+      { config, den, ... }:
+      {
+        den.hosts.x86_64-linux.homehost.users.ben = { };
+        den.homes.x86_64-linux."ben@homehost" = { };
+
+        den.aspects.ben.homeManager.home = {
+          username = "ben";
+          homeDirectory = "/home/ben";
+        };
+        den.aspects.ben.provides.homehost = {
+          homeManager.programs.zsh.profileExtra = "brew";
+        };
+
+        expr = config.flake.homeConfigurations."ben@homehost".config.programs.zsh.profileExtra;
+        expected = "brew";
+      }
+    );
+
+    # Faithful to the user's original report: a darwin standalone home using
+    # `provides.<hostname>` with a hyphenated host name (quoted attr key,
+    # matched by `host.name == key`) and a multiline profileExtra. No host is
+    # declared and no nix-darwin input is imported — the `user@host` name
+    # synthesizes the host identity, so the cross-policy fires.
+    test-darwin-home-provides-synthetic-host-grammar = denTest (
+      { config, den, ... }:
+      {
+        den.homes.aarch64-darwin."ben@Bens-MacBook-Pro" = { };
+
+        den.aspects.ben.homeManager.home = {
+          username = "ben";
+          homeDirectory = "/Users/ben";
+        };
+        den.aspects.ben.provides.Bens-MacBook-Pro = {
+          homeManager.programs.zsh.profileExtra = ''
+            eval "$(/opt/homebrew/bin/brew shellenv zsh)"
+          '';
+        };
+
+        expr = config.flake.homeConfigurations."ben@Bens-MacBook-Pro".config.programs.zsh.profileExtra;
+        expected = ''
+          eval "$(/opt/homebrew/bin/brew shellenv zsh)"
+        '';
+      }
+    );
+
+    # The `hostname` battery (a `{ host }`-keyed OS aspect, documented for
+    # `den.default.includes`) must not throw on a synthetic-host home: its
+    # `${host.class}` emission is gated on `host ? class`, so it stays inert
+    # for a classless synthetic host while the home still evaluates.
+    test-hostname-battery-inert-on-synthetic-host = denTest (
+      { config, den, ... }:
+      {
+        den.default.includes = [ den.batteries.hostname ];
+
+        den.homes.x86_64-linux."ben@homehost" = { };
+        den.aspects.ben.homeManager.home = {
+          username = "ben";
+          homeDirectory = "/home/ben";
+        };
+
+        expr = config.flake.homeConfigurations."ben@homehost".config.home.username;
+        expected = "ben";
+      }
+    );
+
+    # A list-returning include may nest lists; they are flattened so every
+    # effect is reached rather than silently dropped.
+    test-bound-home-nested-list-include-fires = denTest (
+      {
+        config,
+        den,
+        lib,
+        ...
+      }:
+      {
+        den.hosts.x86_64-linux.homehost.users.ben = { };
+        den.homes.x86_64-linux."ben@homehost" = { };
+
+        den.aspects.ben.homeManager.home = {
+          username = "ben";
+          homeDirectory = "/home/ben";
+        };
+        den.aspects.ben.includes = [
+          (
+            { host, ... }:
+            [
+              (lib.optional (host.name == "homehost") (
+                den.lib.policy.include { homeManager.programs.zsh.profileExtra = "brew"; }
+              ))
+            ]
+          )
+        ];
+
+        expr = config.flake.homeConfigurations."ben@homehost".config.programs.zsh.profileExtra;
+        expected = "brew";
+      }
+    );
+
+  };
+}

--- a/templates/ci/modules/deprecated/homes-perhome.nix
+++ b/templates/ci/modules/deprecated/homes-perhome.nix
@@ -54,7 +54,13 @@
           homeSchema.name = "tux";
           homeSchema.userName = "tux";
           homeSchema.hostName = "igloo";
-          homeSchema.host = null;
+          # A `user@host` home with no declared host now carries a synthetic
+          # host identity (name only) so host-keyed provides/policies resolve
+          # without instantiating a real host. `user` stays null — only the
+          # host is synthesized. See deadbugs/standalone-home-host-context.nix.
+          homeSchema.host = {
+            name = "igloo";
+          };
           homeSchema.user = null;
           configuredUserName = "tux";
           keyboard.model = "standalone";


### PR DESCRIPTION
## Summary

A standalone home named `user@host` could not resolve host-keyed config (`provides.<host>`, `policy.when ({ host, ... }: ...)`) unless the host was declared in `den.hosts.<system>` — and declaring it forces instantiation of the host's platform builder (e.g. `inputs.darwin.lib.darwinSystem`), which a home-only flake should not need.

This synthesizes a minimal `{ name = hostName; }` host **identity** from the `user@host` name when the host isn't declared, so host-name-keyed provides and policies resolve without instantiating a real host. A declared host still wins and remains the only thing that wires `osConfig`.

Reproduces the original report: a darwin standalone home using `provides.Bens-MacBook-Pro` now resolves with **no host declared and no nix-darwin import** (`test-darwin-home-provides-synthetic-host-grammar`).

## Design

- **Host-only synthesis** (`home.nix`): only `host` is synthesized, never `user`. A lone synthetic host fires `{ host }`-keyed policies, while `{ host, user }` OS batteries (define-user, user-to-host, …) keep their existing null-user gating and fall back to their home-scope path.
- **Cross-policy** (`provide.nix`): the named `provides.<name>` cross-policy now treats all entity args as optional and gates delivery on `user != null || home != null`. This reaches both user and home scopes (required-arg-based late-dispatch kind matching would otherwise restrict it to a single kind) while staying inert at a bare host scope.
- **`host ? class` invariant**: every `{ host }`-keyed OS-output aspect (os-class, unfree, insecure, hostname, flake-parts inputs'/self') gates OS-class routing/imports on `host ? class`, symmetric with the existing `home ? class` / `user ? classes` guards. A classless synthetic host produces no OS output.

## Also

Fixes a related crash: an aspect `includes` function returning a list of effects (e.g. `lib.optional cond (policy.include {...})`) threw "expected a set but found a list". `mkParametricNext` now normalizes a list return into includes (include-effect descriptors contribute their `.value`, bare aspects pass through, nested lists are flattened, other effect kinds throw a clear `den:` error).

## Tests

`templates/ci/modules/deadbugs/standalone-home-host-context.nix` (10 tests): synthetic-host darwin grammar, declared-host paths, both include grammars (set + list + nested-list), multi-include, non-include-effect error, the `hostname` battery staying inert on a synthetic host, and the no-fire plain-home path.

`just ci`: **889/889**.