### PR TITLE
fix: missing host class in batteries

### DIFF
--- a/modules/aspects/batteries/insecure/insecure.nix
+++ b/modules/aspects/batteries/insecure/insecure.nix
@@ -38,7 +38,7 @@ let
         # nixpkgs.config.permittedInsecurePackages covers these packages.
         hostModule = lib.optionalAttrs (
           (class == "homeManager" || !builtins.elem class validClasses)
-          && host != null
+          && host ? class
           && builtins.elem host.class validClasses
         ) { ${host.class}.permittedInsecurePackages.packages = allowed-names; };
       in

--- a/modules/aspects/batteries/unfree/unfree.nix
+++ b/modules/aspects/batteries/unfree/unfree.nix
@@ -40,7 +40,7 @@ let
         #   - "user" class (no HM) → only the host's OS config exists
         hostModule = lib.optionalAttrs (
           (class == "homeManager" || !builtins.elem class validClasses)
-          && host != null
+          && host ? class
           && builtins.elem host.class validClasses
         ) { ${host.class}.unfree.packages = allowed-names; };
       in


### PR DESCRIPTION
With PR #605 standalone homes have a host identity. This caused the check to pass even though the host has no class causing the unfree battery to fail with the following error:
```
       error: attribute 'class' missing
       at /nix/store/wnv7bc1psj89ylp29z3kabkbpwja0npn-source/modules/aspects/batteries/unfree/unfree.nix:44:28:
           43|           && host != null
           44|           && builtins.elem host.class validClasses
             |                            ^
           45|         ) { ${host.class}.unfree.packages = allowed-names; };
```
This PR changes a host existence check to the availability of its class.