### PR TITLE
fix(ci): live label queries, real allow-ci gating, dead triggers

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -13,11 +13,23 @@ jobs:
   allow-bench:
     name: allow-bench
     runs-on: ubuntu-latest
-    if: ${{contains(github.event.pull_request.labels.*.name, 'allow-bench')}}
+    outputs:
+      allowed: ${{ steps.check.outputs.allowed }}
     steps:
-      - run: true
+      # labels queried live, not from github.event: re-runs reuse the payload
+      # frozen at trigger time and would never see a label added afterwards
+      - id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels --jq '.[].name' | grep -qx 'allow-bench'; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "allowed=false" >> "$GITHUB_OUTPUT"
+          fi
   benchmark:
     needs: [allow-bench]
+    if: ${{needs.allow-bench.outputs.allowed == 'true'}}
     runs-on: ubuntu-latest
     steps:
       - uses: wimpysworld/nothing-but-nix@v10
@@ -26,5 +38,10 @@ jobs:
       - uses: actions/checkout@v6
       - run: git fetch origin ${{github.base_ref}} --depth 1
       - run: nix develop -c just -- bench --head HEAD --base origin/${{github.base_ref}} --warm "$WARM" --runs "$RUNS" -- --show-output 2>&1 | tee "$GITHUB_STEP_SUMMARY" /tmp/den-bench.log
-      - run: grep "faster than base" "/tmp/den-bench.log"
-        if: ${{!contains(github.event.pull_request.labels.*.name, 'bench-skip')}}
+      - env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels --jq '.[].name' | grep -qx 'bench-skip'; then
+            exit 0
+          fi
+          grep "faster than base" "/tmp/den-bench.log"

--- a/.github/workflows/bogus.yml
+++ b/.github/workflows/bogus.yml
@@ -1,7 +1,9 @@
 name: bogus
 on:
   push:
-    branches: ["!main"]
+    # branches: ["!main"] never matched anything: a filter with only negative
+    # patterns matches no branch at all
+    branches-ignore: [main]
     paths: ["templates/bogus/**/*.nix"]
   pull_request:
     types: [labeled, opened, synchronize, reopened, review_requested, ready_for_review]
@@ -19,7 +21,7 @@ jobs:
     name: Bogus (den ${{matrix.rev}})
     runs-on: ${{matrix.os}}
     steps:
-      - uses: wimpysworld/nothing-but-nix@main
+      - uses: wimpysworld/nothing-but-nix@v10
       - uses: cachix/install-nix-action@v31
       - uses: DeterminateSystems/magic-nix-cache-action@v13
       - run: nix flake init -t "github:${GITHUB_REPOSITORY}/${GITHUB_SHA}#bogus"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,20 +1,25 @@
 name: Docs
 on:
   push:
-    branches: ["!main"]
+    # branches: ["!main"] never matched anything: a filter with only negative
+    # patterns matches no branch at all
+    branches-ignore: [main]
     paths: ["docs/**"]
   pull_request:
     types: [labeled, opened, synchronize, reopened, review_requested, ready_for_review]
     paths: ["docs/**"]
   pull_request_review:
     types: [submitted]
+# group per ref so concurrent PRs don't cancel each other's docs builds
 concurrency:
-  group: "docs"
+  group: docs-${{ github.ref }}
   cancel-in-progress: true
 env:
   NIX_PATH: "nixpkgs=https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz"
 jobs:
   build:
+    # review events: only approvals re-trigger; comment reviews shouldn't burn a build
+    if: ${{github.event_name != 'pull_request_review' || github.event.review.state == 'approved'}}
     runs-on: ubuntu-latest
     steps:
       - uses: wimpysworld/nothing-but-nix@v10

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -26,8 +26,9 @@ jobs:
       - uses: DeterminateSystems/magic-nix-cache-action@v13
       - uses: actions/checkout@v6
       - run: mkdir -p ~/versioned/docs
-      - run: gh api "/repos/$GITHUB_REPOSITORY/actions/artifacts" | tee ~/versioned/artifacts.json
-      - run: jq -r '.artifacts | map({id,name,expired} | select(.expired == false and (.name | match("docs-")))) | group_by(.name) | map(.[0])' ~/versioned/artifacts.json | tee ~/versioned/docs.json
+      # paginate so versioned docs survive past 30 artifacts; newest artifact wins per name
+      - run: gh api --paginate "/repos/$GITHUB_REPOSITORY/actions/artifacts" --jq '.artifacts[]' | jq -s '.' | tee ~/versioned/artifacts.json
+      - run: jq -r 'map({id,name,expired} | select(.expired == false and (.name | match("docs-")))) | group_by(.name) | map(max_by(.id))' ~/versioned/artifacts.json | tee ~/versioned/docs.json
       - run: |
           for id in $(jq -r 'map(.id)|.[]'  ~/versioned/docs.json); do
             gh api "/repos/$GITHUB_REPOSITORY/actions/artifacts/${id}/zip" > ~/versioned/${id}.zip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,58 +11,88 @@ on:
   workflow_dispatch:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # never cancel main builds: back-to-back merges would leave main untested
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 env:
   NIX_PATH: "nixpkgs=https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz"
 jobs:
   non-draft:
     runs-on: ubuntu-latest
-    if: ${{github.ref == 'refs/heads/main' || github.event.pull_request.draft == false}}
+    # review events: only approvals re-trigger CI; comment reviews would
+    # otherwise produce skipped check runs that overwrite real test results
+    if: ${{github.ref == 'refs/heads/main' || (github.event.pull_request.draft == false && (github.event_name != 'pull_request_review' || github.event.review.state == 'approved'))}}
+    outputs:
+      nix-changed: ${{ steps.diff.outputs.nix-changed }}
     steps:
       - uses: actions/checkout@v6
-      - run: |
-          git fetch --depth 1 origin refs/heads/main
-          test "refs/heads/main" == "${{github.ref}}" || (git diff --name-only origin/main..${{ github.sha }} -- | grep '.nix')
-  ci-deep:
+      - id: diff
+        # pull_request_review has no paths filter, so docs-only PRs reach here;
+        # downstream jobs skip on nix-changed=false (skipped required checks
+        # count as passing, which is what lets docs-only PRs merge)
+        run: |
+          if [[ "${{github.ref}}" == "refs/heads/main" ]]; then
+            echo "nix-changed=true" >> "$GITHUB_OUTPUT"
+          else
+            git fetch --depth 1 origin refs/heads/main
+            if git diff --name-only origin/main..${{github.sha}} -- | grep -q '\.nix$'; then
+              echo "nix-changed=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "nix-changed=false" >> "$GITHUB_OUTPUT"
+            fi
+          fi
+  allow-ci:
     needs: [non-draft]
+    name: allow-ci
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check access
+        if: ${{github.event_name == 'pull_request' || github.event_name == 'pull_request_review'}}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # labels are queried live, not from github.event: re-runs reuse the
+        # payload frozen at trigger time, so a label added after a failure
+        # would never be seen. auto-allow-ci's GITHUB_TOKEN labeling also does
+        # not re-trigger workflows, hence the permission-check fallback.
+        run: |
+          if gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels --jq '.[].name' | grep -qx 'allow-ci'; then
+            exit 0
+          fi
+          perm=$(gh api repos/${{ github.repository }}/collaborators/${{ github.event.pull_request.user.login }}/permission --jq '.permission') || perm=none
+          if [[ "$perm" != "admin" && "$perm" != "write" ]]; then
+            echo "::error::PR author does not have write access and PR is missing allow-ci label"
+            exit 1
+          fi
+  ci-deep:
+    needs: [non-draft, allow-ci]
+    # runs even when allow-ci fails so the required check goes red instead of
+    # skipped (skipped required checks count as passing and would allow merge)
+    if: ${{!cancelled() && needs.non-draft.result == 'success' && needs.non-draft.outputs.nix-changed == 'true'}}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
     name: Tests ${{matrix.os}}
     runs-on: ${{matrix.os}}
     steps:
+      - name: Require allow-ci
+        run: test "${{needs.allow-ci.result}}" == "success"
       - uses: wimpysworld/nothing-but-nix@v10
       - uses: cachix/install-nix-action@v31
       - uses: DeterminateSystems/magic-nix-cache-action@v13
       - uses: actions/checkout@v6
       - run: nix-shell --run 'just ci-deep'
   flake-check:
-    needs: [non-draft]
+    needs: [non-draft, allow-ci]
+    if: ${{!cancelled() && needs.non-draft.result == 'success' && needs.non-draft.outputs.nix-changed == 'true'}}
     name: nix flake check
     runs-on: ubuntu-latest
     steps:
+      - name: Require allow-ci
+        run: test "${{needs.allow-ci.result}}" == "success"
       - uses: cachix/install-nix-action@v31
       - run: nix flake check -L github:vic/checkmate --override-input target github:$GITHUB_REPOSITORY/$GITHUB_SHA
-  allow-ci:
-    needs: [non-draft]
-    name: allow-ci
-    runs-on: ubuntu-latest
-    # Label check kept as fast-path; permission check runs when label is absent.
-    # auto-allow-ci adds the label via GITHUB_TOKEN which does not re-trigger
-    # workflows, so the label may not be present on the first run.
-    steps:
-      - name: Check access
-        if: ${{github.ref != 'refs/heads/main' && !contains( github.event.pull_request.labels.*.name, 'allow-ci')}}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          perm=$(gh api repos/${{ github.repository }}/collaborators/${{ github.event.pull_request.user.login }}/permission --jq '.permission')
-          if [[ "$perm" != "admin" && "$perm" != "write" ]]; then
-            echo "::error::PR author does not have write access and PR is missing allow-ci label"
-            exit 1
-          fi
   noflake:
-    needs: [allow-ci]
+    needs: [non-draft, allow-ci]
+    if: ${{needs.non-draft.outputs.nix-changed == 'true'}}
     name: noflake
     runs-on: ubuntu-latest
     steps:
@@ -81,7 +111,8 @@ jobs:
       - run: (cd templates/noflake && nix-build ./default.nix -A flake.nixosConfigurations.igloo.config.system.build.toplevel)
       - run: (cd templates/noflake && nix-shell ./default.nix -A den.sh --run 'igloo build --offline')
   template:
-    needs: [allow-ci]
+    needs: [non-draft, allow-ci]
+    if: ${{needs.non-draft.outputs.nix-changed == 'true'}}
     # max-parallel: 2
     strategy:
       matrix:
@@ -115,7 +146,8 @@ jobs:
       - run: (cd templates/flake-parts-modules && nix develop .# --override-input den github:$GITHUB_REPOSITORY/$GITHUB_SHA --command cowsay)
         if: matrix.template == 'flake-parts-modules'
   flake-file-template:
-    needs: [allow-ci]
+    needs: [non-draft, allow-ci]
+    if: ${{needs.non-draft.outputs.nix-changed == 'true'}}
     strategy:
       matrix:
         os: [ubuntu-latest]


### PR DESCRIPTION
## Why

PR #606 exposed a CI gating bug: re-running the failed `allow-ci` job kept failing even after the `allow-ci` label was added. The label check read `github.event.pull_request.labels` — a payload frozen at trigger time, which re-runs reuse verbatim. A general audit of the workflows turned up several more robustness issues.

## Changes

### test.yml
- **`allow-ci` queries labels live** via the API instead of the event payload, so re-runs see labels added after the triggering event. Permission-check fallback kept (auto-allow-ci's `GITHUB_TOKEN` labeling doesn't re-trigger workflows).
- **`ci-deep` and `flake-check` are now actually gated by `allow-ci`** — previously they ran for fork PRs regardless; the gate only protected the cheap template jobs. They fail (via a `Require allow-ci` first step) rather than skip, because skipped required checks count as passing under the ruleset and would let an unvetted PR satisfy `Tests ubuntu-latest`. **Behavior change:** external PRs get no CI until labeled, matching the gate's stated intent.
- **Main builds are never cancelled**: `cancel-in-progress` is now conditional. Back-to-back merges to main previously cancelled each other's runs, leaving main untested.
- **`non-draft` emits a `nix-changed` output** instead of failing `grep '.nix'` on docs-only PRs (red ❌ on every review of a non-nix PR). Downstream jobs skip cleanly, preserving the skipped-required-checks path that lets docs-only PRs merge. Also fixes the unescaped-dot regex.
- **Only approved reviews re-trigger CI** — `pull_request_review: submitted` previously fired full CI on comment/changes-requested reviews too.

### benchmark.yml
- Same live-label-query fix for `allow-bench` and `bench-skip`.

### bogus.yml / docs.yml
- `branches: ["!main"]` was a dead trigger — a filter with only negative patterns matches no branch at all. Replaced with `branches-ignore: [main]`.
- docs concurrency group is per-ref; the global `"docs"` group made concurrent PRs cancel each other's builds. Review-triggered docs builds gated to approvals.
- `nothing-but-nix` pinned to `@v10` in bogus.yml for consistency.

### gh-pages.yml
- Artifact listing paginates (previously capped at 30 — old doc versions silently dropped) and picks the newest artifact per `docs-*` name instead of an arbitrary one.

## Not changed (flagged)

- Actions are tag-pinned, not SHA-pinned (`EndBug/latest-tag@latest` in particular) — separate supply-chain hardening if desired.
- `pull_request_review` keeps no paths filter by design: it's the re-trigger lever and the docs-only-merge mechanism.

Validated with `actionlint` (only pre-existing info-level SC2086 notes remain) and `just fmt`.