### PR TITLE
fix(docs): Remove deprecated link

### DIFF
--- a/docs/src/content/docs/motivation.mdx
+++ b/docs/src/content/docs/motivation.mdx
@@ -64,7 +64,7 @@ An important point is that parametric aspect's context **are not** _module.args,
 
 
 <Aside>
-Some [people](https://codeberg.org/FrdrCkII/nixconf/src/commit/9bef0f86a790d93c20e693dc4c020c83b0396e8f/lib/aspects.prt.nix) have found [`flake-aspects`](https://github.com/denful/flake-aspects) enough to implement their own Dendritic setups, or even for mixing with other non-dendritic infra.
+Some people have found [`flake-aspects`](https://github.com/denful/flake-aspects) enough to implement their own Dendritic setups, or even for mixing with other non-dendritic infra.
 </Aside>
 
 ## Den builds upon flake-aspects


### PR DESCRIPTION
The original repository has been force-pushed, archived, and the pattern has been removed. Thus, the link is removed entirely.