### PR TITLE
fix: preserve source entity binding in forward fallback

### DIFF
--- a/nix/lib/aspects/fx/edges/materialize-unified.nix
+++ b/nix/lib/aspects/fx/edges/materialize-unified.nix
@@ -110,6 +110,7 @@ let
         scopeContexts
         scopeParent
         scopeIsolated
+        scopeEntityKind
         ;
       # Stable scope name for the trace-edge construction (ordering only).
       name = den.lib.aspects.fx.edges.edge.scopeName {
@@ -176,6 +177,7 @@ let
               rootScopeId
               scopeContexts
               scopeParent
+              scopeEntityKind
               spawnNode
               buildForwardAspect
               ;

--- a/nix/lib/aspects/fx/edges/route.nix
+++ b/nix/lib/aspects/fx/edges/route.nix
@@ -31,6 +31,7 @@ let
     synthesize
     rootTarget
     ;
+  inherit (import ./spawn-context.nix { inherit lib; }) mkSourceScopeBindings;
   inherit (import ../scope-walk.nix { inherit lib; }) subtreeScopes;
 
   # ===== materialization mechanics (ported from route/wrap.nix) ==========
@@ -579,7 +580,7 @@ let
   # edges here would double-count the same delivery. Only the drain-fold spawn
   # (resolve.nix mkDrained) surfaces edges into unifiedEdges.
   resolveSourceFallback =
-    spec: spawnNode: scopeParent:
+    spec: spawnNode: scopeParent: scopeContexts: scopeEntityKind:
     if !(spec ? sourceAspect) || spawnNode == null || !(spec ? sourceScopeId) then
       [ ]
     else
@@ -587,7 +588,10 @@ let
         from = scopeParent.${spec.sourceScopeId} or spec.sourceScopeId;
         class = spec.fromClass;
         aspect = den.lib.aspects.normalizeRoot spec.sourceAspect;
-        bindings = { };
+        bindings = mkSourceScopeBindings {
+          inherit scopeContexts scopeEntityKind;
+          sourceScopeId = spec.sourceScopeId;
+        };
       }).imports;
 
   # Append synthesized modules to a class bucket at a scope (flat + perScope).
@@ -615,6 +619,7 @@ let
       rootScopeId,
       scopeContexts,
       scopeParent,
+      scopeEntityKind,
       spawnNode,
       buildForwardAspect,
     }:
@@ -625,7 +630,7 @@ let
         if collectedSource != [ ] then
           collectedSource
         else
-          resolveSourceFallback spec spawnNode scopeParent;
+          resolveSourceFallback spec spawnNode scopeParent scopeContexts scopeEntityKind;
       sourceModule = spec.mapModule { imports = sourceModules; };
       newMods = collectClassMods spec.intoClass (buildForwardAspect spec sourceModule);
     in
@@ -706,6 +711,7 @@ let
       scopeParent ? { },
       scopeIsolated ? { },
       scopeContexts ? { },
+      scopeEntityKind,
       spawnNode ? null,
       rootScopeId ? null,
       buildForwardAspect ? null,
@@ -723,6 +729,7 @@ let
               rootScopeId
               scopeContexts
               scopeParent
+              scopeEntityKind
               spawnNode
               buildForwardAspect
               ;

--- a/nix/lib/aspects/fx/edges/spawn-context.nix
+++ b/nix/lib/aspects/fx/edges/spawn-context.nix
@@ -1,0 +1,17 @@
+{ ... }:
+{
+  # Fallback rewalk starts from the parent scope for fleet visibility, so restore
+  # the source scope's own entity binding (for example, `user`) explicitly.
+  mkSourceScopeBindings =
+    {
+      scopeContexts,
+      scopeEntityKind,
+      sourceScopeId,
+    }:
+    let
+      sourceCtx = scopeContexts.${sourceScopeId} or { };
+      ownKind = scopeEntityKind.${sourceScopeId} or null;
+      ownRecord = if ownKind == null then null else sourceCtx.${ownKind} or null;
+    in
+    if ownRecord == null then { } else { ${ownKind} = ownRecord; };
+}

--- a/nix/lib/aspects/fx/resolve.nix
+++ b/nix/lib/aspects/fx/resolve.nix
@@ -74,13 +74,14 @@ let
   # complex-route forward SOURCE with full fleet visibility (replaces the old
   # isolated fxResolve fallback).
   applyRoutes =
-    spawnNode: ctx: scopeContexts: rootScopeId: scopeParent: scopeIsolated: scopedRoutes: acc:
+    spawnNode: ctx: scopeContexts: rootScopeId: scopeParent: scopeIsolated: scopeEntityKind: scopedRoutes: acc:
     routeEdges.applyRoutes {
       inherit
         scopedRoutes
         scopeContexts
         scopeParent
         scopeIsolated
+        scopeEntityKind
         rootScopeId
         spawnNode
         ;
@@ -983,6 +984,7 @@ let
           oraclePhase2 = applyProvidesEdges ctx scopedProvides phase1;
           oraclePhase3 =
             applyRoutes spawnNode ctx augmentedScopeContexts result.state.rootScopeId scopeParent scopeIsolated
+              scopeEntityKind
               scopedRoutes
               oraclePhase2;
         in

--- a/templates/ci/modules/deadbugs/hm-platform-forward.nix
+++ b/templates/ci/modules/deadbugs/hm-platform-forward.nix
@@ -1,0 +1,90 @@
+# Regression for discussion #620:
+# `docs/src/content/docs/guides/custom-classes.mdx`,
+# "Example: Platform specific `hm` classes".
+#
+# The documented `hmPlatforms` forward failed for a host user with
+# "spawnNode spawn root equals its parent scope".
+{ denTest, ... }:
+{
+  flake.tests.deadbugs.hm-platform-forward = {
+
+    # Docs example: forward `hmLinux`, guard out `hmDarwin`.
+    test-doc-example-forwards-linux-only = denTest (
+      {
+        den,
+        lib,
+        tuxHm,
+        ...
+      }:
+      let
+        hmPlatforms =
+          { class, aspect-chain }:
+          den.batteries.forward {
+            each = [
+              "Linux"
+              "Darwin"
+              "Aarch64"
+              "64bit"
+            ];
+            fromClass = platform: "hm${platform}";
+            intoClass = _: "homeManager";
+            intoPath = _: [ ];
+            fromAspect = _: lib.head aspect-chain;
+            guard = { pkgs, ... }: platform: lib.mkIf pkgs.stdenv."is${platform}";
+            adaptArgs =
+              { config, ... }:
+              {
+                osConfig = config;
+              };
+          };
+      in
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+        den.aspects.tux = {
+          includes = [ hmPlatforms ];
+
+          hmLinux.home.sessionVariables.HM_PLATFORM = "linux";
+
+          hmDarwin.home.sessionVariables.HM_PLATFORM_DARWIN = "darwin";
+        };
+
+        expr = {
+          linux = tuxHm.home.sessionVariables.HM_PLATFORM or null;
+          darwin = tuxHm.home.sessionVariables.HM_PLATFORM_DARWIN or null;
+        };
+        expected = {
+          linux = "linux";
+          darwin = null;
+        };
+      }
+    );
+
+    # Unknown source class: forwarding an undeclared, unused class into an
+    # evaluated class should be inert, not crash during fallback rewalk.
+    test-unknown-source-class-to-home-manager-is-inert = denTest (
+      {
+        den,
+        lib,
+        igloo,
+        ...
+      }:
+      let
+        forwardUnknownSource =
+          { aspect-chain, ... }:
+          den.batteries.forward {
+            each = [ true ];
+            fromClass = _: "unusedSource";
+            intoClass = _: "homeManager";
+            fromAspect = _: lib.head aspect-chain;
+          };
+      in
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+        den.aspects.tux.includes = [ forwardUnknownSource ];
+
+        expr = igloo.home-manager.users.tux.home.stateVersion;
+        expected = "25.11";
+      }
+    );
+  };
+}


### PR DESCRIPTION
## Problem

Refs #620.

The documented platform-specific `hmPlatforms` example can fail when a
user-scoped complex forward includes a `fromClass` whose class key never appears
in the user's aspect tree and is not explicitly registered in `den.classes`.

For example, a user may include `hmPlatforms` and define only `hmLinux` content.
The generated forward for another class, such as `hmDarwin`, then has no
collected source modules when there is no `hmDarwin` key in that user's aspect
tree and `hmDarwin` is not registered as a class.

In that case `getCollectedSource` returns `[]`, so `resolveSourceFallback`
rewalks the source aspect from the parent scope to keep fleet visibility. That
fallback used `bindings = { }`, dropping the source scope's entity binding. For
a user-scoped forward, losing the `user` binding can make the spawn collapse
into a self-parent edge:

```
den: spawnNode spawn root equals its parent scope 'host=igloo,system=x86_64-linux'
— a self-parent edge collapses policyBoundAncestor to null and yields zero fleet peers.
The seed ctx likely lost its child binding (e.g. `user`).
```

## Fix

Restore the source scope's entity binding during complex forward fallback
rewalk.

The binding reconstruction mirrors the existing
[`mkDrained` drained-spawn path](https://github.com/denful/den/blob/70dfa3a38f19a163715fbbc64d568a00f93820be/nix/lib/aspects/fx/resolve.nix#L568-L705):

https://github.com/denful/den/blob/70dfa3a38f19a163715fbbc64d568a00f93820be/nix/lib/aspects/fx/resolve.nix#L677-L679

https://github.com/denful/den/blob/70dfa3a38f19a163715fbbc64d568a00f93820be/nix/lib/aspects/fx/resolve.nix#L702-L704

The fallback now follows the same pattern: look up the source scope's entity
kind, read that entity from `scopeContexts`, and pass it as the spawn binding.

This keeps the existing parent-scope spawn behavior for fleet visibility, while
preserving bindings like `user` when the `sourceScopeId` is a child entity
scope.

## Tests

Added `deadbugs.hm-platform-forward` covering:

- the docs `hmPlatforms` shape: active `hmLinux` forwards, inactive `hmDarwin`
  stays inert
- an undeclared/unused source class forwarded into `homeManager`, which should
  be inert rather than crash

Both new regression tests fail on the [test-only commit](https://github.com/denful/den/commit/6cc413d117483a053bad3c2e9eabc8a041b77c63) with `spawnNode spawn root equals its parent scope` and pass with this fix.

Validated locally:

- `just ci deadbugs.hm-platform-forward.test-doc-example-forwards-linux-only`
- `just ci deadbugs.hm-platform-forward.test-unknown-source-class-to-home-manager-is-inert`
- `just fmt`
- `just ci`: **1036/1036 successful**

## AI assistance

I used AI assistance while preparing this contribution:

- `ChatGPT 5.5 Thinking` helped me understand the complex forward fallback path,
  analyze the dropped source scope entity binding, and notice the existing
  `mkDrained` binding reconstruction pattern.
- `Codex GPT-5.5 medium` helped with contribution workflow, test strategy,
  fail/pass comparison, test naming/comments, and English wording.

I also used AI to translate and polish English because I am not fluent in
written English. I reviewed the final text, understand the code changes and PR
description, removed repetition, kept the diff minimal and focused, and ran the
final tests locally.

I `Gyeongmin Song`, explicitly acknowledge the following:

- [x] My contribution is AI generated and I mention which models/mcp-servers/tools were used.
- [x] I recognize AI generated contribution as my own and am myself legally accountable for it.
- [x] My contribution aligns with Den LICENSE and does not violate any other projects licenses (e.g. GPL)
- [x] I will truthfully answer and provide any requested details on how contribution was generated.
