### PR TITLE
fix: fan class-module entity args over scope descendants (#629)

### DIFF
--- a/nix/lib/aspects/fx/handlers/compile.nix
+++ b/nix/lib/aspects/fx/handlers/compile.nix
@@ -2,29 +2,88 @@
 # Shape router — dispatches to compile-* based on aspect shape.
 {
   den,
+  lib,
   ...
 }:
 let
   inherit (den.lib) fx;
+  inherit (den.lib.aspects.fx) argClass;
+  inherit (den.lib.aspects.fx.contentUtil) unwrapContentValuesList;
+  inherit (den.lib.schemaUtil) schemaEntityKindsSet;
+  schema = den.schema or { };
+  classReg = den.classes or { };
+
+  # Entity kinds NAMED as function args by a static aspect's class-content
+  # modules, unioned across every class key. Mirrors emit-classes.nix
+  # `namedEntityArgs` (bare-fn modules only) but does NOT gate on ctx — the
+  # router decides fan-out eligibility via the schema DAG (see below).
+  namedClassEntityKinds =
+    aspect:
+    let
+      classKeys = builtins.filter (k: classReg ? ${k}) (builtins.attrNames aspect);
+      kindsIn =
+        module:
+        if builtins.isFunction module then
+          builtins.filter (a: schemaEntityKindsSet ? ${a}) (builtins.attrNames (builtins.functionArgs module))
+        else
+          [ ];
+    in
+    lib.unique (
+      builtins.concatMap (k: builtins.concatMap kindsIn (unwrapContentValuesList aspect.${k})) classKeys
+    );
 in
 {
   compileHandler = {
     "compile" =
       { param, state }:
       let
-        meta = param.aspect.meta or { };
+        aspect = param.aspect;
+        meta = aspect.meta or { };
+        isStatic =
+          !(meta ? __forward) && !(meta ? guard) && !(aspect ? __fn) && (aspect.__args or { }) == { };
+
+        # A class-content module naming a strict DESCENDANT of the emitting scope's
+        # kind (host-scope aspect with `nixos = { user, ... }:`) has no such binding
+        # in scope, so wrapClassModule would drop it silently. Promote the aspect to
+        # be parametric on those kinds: the bind handler then fans it per descendant
+        # instance via the SAME machinery the aspect-level `{ user, ... }:` form uses,
+        # making the two forms equivalent. Descendant classification (not mere
+        # ctx-absence) keeps scope-kind-self and ancestor args on the static path —
+        # bind would only satisfy or inert those. `__parametricResolvedArgs` excludes
+        # kinds already bound by an earlier fan, so the re-resolved body (still naming
+        # the kind) does not re-promote into a loop.
+        scopeKind = ((state.scopeEntityKind or (_: { })) null).${state.currentScope or ""} or null;
+        resolvedArgs = aspect.__parametricResolvedArgs or [ ];
+        promoteKinds =
+          if isStatic && scopeKind != null then
+            builtins.filter (
+              k: (argClass.isDescendantOf schema scopeKind k) && !(builtins.elem k resolvedArgs)
+            ) (namedClassEntityKinds aspect)
+          else
+            [ ];
+        promoted =
+          if promoteKinds != [ ] then
+            aspect
+            // {
+              __fn = _: aspect;
+              __args = lib.genAttrs promoteKinds (_: false);
+              __functor = self: self.__fn;
+            }
+          else
+            aspect;
+
         effect =
           if meta ? __forward then
             "compile-forward"
           else if meta ? guard then
             "compile-conditional"
-          else if param.aspect ? __fn || (param.aspect.__args or { }) != { } then
+          else if promoted ? __fn || (promoted.__args or { }) != { } then
             "compile-parametric"
           else
             "compile-static";
       in
       {
-        resume = fx.send effect param;
+        resume = fx.send effect (param // { aspect = promoted; });
         inherit state;
       };
   };

--- a/templates/ci/modules/features/deadbugs/issue-629-class-module-user-arg.nix
+++ b/templates/ci/modules/features/deadbugs/issue-629-class-module-user-arg.nix
@@ -1,0 +1,54 @@
+# Issue #629: requesting `user` inside an aspect's `nixos` class module silently
+# drops the module when the aspect is included at HOST scope.
+#
+# Reporter includes an aspect at host scope whose `nixos` class module names
+# `user`. At host scope the emit ctx has `host` but no `user`, so wrapClassModule
+# marks it `unsatisfied` and wrap-classes drops it (silently — the lib.warn is
+# attached to the discarded module and never forced). The aspect-level parametric
+# form `{ user, ... }: { nixos = ...; }` works because the bind handler fans the
+# aspect over host.users; class-module args never reach that fan-out.
+{ denTest, ... }:
+{
+  flake.tests.deadbugs.issue-629-class-module-user-arg = {
+
+    # FAILING: class module names `user`, aspect included at host scope.
+    # Host has one user; the module should fan per-user like the aspect form.
+    test-class-module-user-arg-at-host-scope = denTest (
+      { den, igloo, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.desktop.cosmic.nixos =
+          { user, ... }:
+          {
+            environment.etc."cosmic-autologin".text = user.userName;
+          };
+
+        den.aspects.igloo.includes = [ den.aspects.desktop.cosmic ];
+
+        expr = igloo.environment.etc."cosmic-autologin".text or "<skipped>";
+        expected = "tux";
+      }
+    );
+
+    # CONTROL: aspect-level parametric form of the same thing — already works.
+    test-aspect-level-parametric-at-host-scope = denTest (
+      { den, igloo, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.desktop.cosmic =
+          { user, ... }:
+          {
+            nixos.environment.etc."cosmic-autologin".text = user.userName;
+          };
+
+        den.aspects.igloo.includes = [ den.aspects.desktop.cosmic ];
+
+        expr = igloo.environment.etc."cosmic-autologin".text or "<skipped>";
+        expected = "tux";
+      }
+    );
+
+  };
+}


### PR DESCRIPTION
Fixes #629.

## Problem

Requesting an entity arg (e.g. `user`) inside a class module was silently dropped when the aspect is included at a scope where that entity is a *descendant* — the reporter's `nixos = { user, ... }:` at host scope:

```nix
den.aspects.desktop.cosmic.nixos =
  { user, ... }:
  { services.displayManager.autoLogin.user = user.userName; };
den.aspects.void.includes = [ den.aspects.desktop.cosmic ];  # host has user `lucas`
```

The whole `nixos` module vanished — no config, no options, no error. The only workaround was lifting the entity arg to the aspect level (`{ user, ... }: { nixos = ...; }`), which *does* fan per-user.

## Root cause

At host scope the emit-time ctx has `host` but no `user`, so `wrapFunctionModule` (`class-module.nix`) marks the module `unsatisfied` and `wrap-classes.nix` returns `[ ]` for it — dropped. The aspect-level form works because the `bind` handler fans the aspect over the scope's descendant entities (`host.users`); class-module function args never reached that fan-out.

(The `lib.warn` meant to flag this is attached to the discarded module, so it never fires — hence "silent". Left as a separate observability concern: the descendant case no longer skips, and reviving the warn unconditionally would noise up the intentional guard-skip pattern.)

## Fix

In the compile shape router, a **static** aspect whose class-content module names a strict **descendant** of the emitting scope's entity kind is promoted to a parametric aspect on those kinds. The `bind` handler then fans it per descendant instance via the exact same machinery the aspect-level `{ user, ... }:` form uses — making the two forms equivalent.

- **Descendant classification** (`argClass.isDescendantOf`), not mere ctx-absence: scope-kind-self and ancestor args stay on the static path (bind would only satisfy/inert them), so `nixos = { host, ... }:` and user-scope resolution are unchanged.
- **`__parametricResolvedArgs` guard**: excludes kinds already bound by an earlier fan, so the re-resolved body (which still names the kind) can't re-promote into a loop.

## Testing

- New regression: `templates/ci/modules/features/deadbugs/issue-629-class-module-user-arg.nix` — the class-module form now fans; the aspect-level control still works.
- `user-scoped-host-class-fanout`, `nested-class-module-args` (incl. `test-guard-skips-without-context`), `top-level-parametric`, `auto-parametric` all green.
- Full suite: **1059/1059 successful**.