### PR TITLE
feat: add environment.shells for darwin

### DIFF
--- a/modules/aspects/batteries/user-shell.nix
+++ b/modules/aspects/batteries/user-shell.nix
@@ -12,26 +12,32 @@ let
       ];
   '';
 
-  userShell =
-    shell: user:
-    let
-      nixos =
-        { pkgs, ... }:
-        {
-          programs.${shell}.enable = true;
-          users.users.${user.userName}.shell = pkgs.${shell};
-        };
-      darwin = nixos;
-      homeManager.programs.${shell}.enable = true;
-    in
-    {
-      inherit nixos darwin homeManager;
+  userShell = shell: user: {
+    nixos =
+      { pkgs, ... }:
+      {
+        programs.${shell}.enable = true;
+        users.users.${user.userName}.shell = pkgs.${shell};
+      };
+
+    darwin =
+      { pkgs, ... }:
+      {
+        programs.${shell}.enable = true;
+        users.users.${user.userName}.shell = pkgs.${shell};
+        environment.shells = [ pkgs.${shell} ];
+      };
+
+    homeManager = {
+      programs.${shell}.enable = true;
     };
+  };
 
 in
 {
   den.batteries.user-shell = shell: {
     inherit description;
+
     includes = [
       ({ host, user }: { name = "user-shell/${user.userName}@${host.name}"; } // userShell shell user)
       ({ home }: { name = "user-shell/${home.name}"; } // userShell shell home)


### PR DESCRIPTION
on macos we must add the shell to `environment.shells` and change the default shell using `chsh -s`