### PR TITLE
fix: keep every definition of a nested aspect key defined across files

### DIFF
--- a/nix/lib/aspects/default.nix
+++ b/nix/lib/aspects/default.nix
@@ -122,6 +122,7 @@ in
   # Predicates exported directly (not through types mapAttrs which applies { } to each value).
   inherit (rawTypes)
     isParametricWrapper
+    isParametricContent
     isSubmoduleFn
     isMeaningfulName
     isSyntheticName

--- a/nix/lib/aspects/fx/aspect/normalize.nix
+++ b/nix/lib/aspects/fx/aspect/normalize.nix
@@ -4,7 +4,12 @@
   den,
 }:
 let
-  inherit (den.lib.aspects) isSubmoduleFn isMeaningfulName isParametricWrapper;
+  inherit (den.lib.aspects)
+    isSubmoduleFn
+    isMeaningfulName
+    isParametricWrapper
+    isParametricContent
+    ;
 
   # Normalize a NixOS module function into an aspect attrset via type merge.
   normalizeModuleFn =
@@ -98,16 +103,7 @@ let
       let
         prov = child.__provider or [ ];
         provName = if prov != [ ] then lib.last prov else null;
-        fns = builtins.filter (
-          d:
-          lib.isFunction d.value
-          && (
-            let
-              args = builtins.functionArgs d.value;
-            in
-            args != { } && !(args ? config) && !(args ? options)
-          )
-        ) (child.__contentValues or [ ]);
+        fns = builtins.filter isParametricContent (child.__contentValues or [ ]);
       in
       child
       // lib.optionalAttrs (provName != null) {

--- a/nix/lib/aspects/types.nix
+++ b/nix/lib/aspects/types.nix
@@ -174,20 +174,31 @@ let
     };
 
   # A parametric function reaching aspectSubmodule.merge is evaluated as a NixOS
-  # module and fails on its own context argument, so every def list handed to the
-  # base type passes through here first.
-  coerceFnDefs = map (
-    d:
-    if lib.isFunction d.value && !isSubmoduleFn d.value then
-      d
-      // {
-        value = {
-          includes = [ d.value ];
-        };
-      }
-    else
-      d
-  );
+  # module and fails on its own context argument, so def lists handed to the base
+  # type pass through here first.
+  #
+  # The predicate is a parameter because the two callers have different domains.
+  # mergeMixed's caller has already split on lib.isFunction, so a functor-carrying
+  # attrset is on the function side by construction and must stay coerced. The
+  # parametric branch has made no such split: every merged aspect carries
+  # __functor, so lib.isFunction there would demote ordinary aspect-valued defs
+  # to includes. Only a bare lambda can reach the module system as a module.
+  coerceFnDefsWith =
+    isFn:
+    map (
+      d:
+      if isFn d.value && !isSubmoduleFn d.value then
+        d
+        // {
+          value = {
+            includes = [ d.value ];
+          };
+        }
+      else
+        d
+    );
+  coerceFnDefs = coerceFnDefsWith lib.isFunction;
+  coerceBareFnDefs = coerceFnDefsWith builtins.isFunction;
 
   # Merge branch: mixed function + attrset defs — coerce parametric fns to includes.
   mergeMixed =
@@ -308,36 +319,42 @@ let
               prov = v.__provider or [ ];
             in
             if prov != [ ] then lib.last prov else null;
-          # A content wrapper holds every definition of its key. Reducing it to
-          # one value drops the others with no diagnostic, so expand it into one
-          # def per parametric function plus one def carrying the static side.
-          # The dispatch below then recombines them through mergeMixed, which is
-          # what handles a fn/attrset mix at an unwrapped key.
-          expandContent =
+          # A content wrapper holds every definition of its key. Taking one value
+          # out of it drops the rest with no diagnostic, so keep the wrapper as a
+          # single def and move its parametric definitions into includes, where
+          # the pipeline resolves them — the same shape wrapChild produces for an
+          # includes element, which listOf hands over without reaching this merge.
+          #
+          # One def rather than one per definition: the wrapper is the only
+          # carrier of __provider, so splitting it leaves the parametric defs
+          # nameless. They then resolve to an anonymous per-inclusion identity,
+          # which defeats gate dedup and duplicates their content once per path.
+          wrapperToAspect =
             d:
             let
               parts = builtins.partition isParametricContent (d.value.__contentValues or [ ]);
               provName = nameFromProvider d.value;
-              # Preserve identity: inject name and provider chain from
-              # __provider so aspectSubmodule.merge produces a meaningful
-              # identity instead of an anonymous include index.
-              staticDef = d // {
-                value =
-                  d.value
-                  // {
-                    __contentValues = parts.wrong;
-                  }
-                  // lib.optionalAttrs (provName != null) {
-                    name = provName;
-                    meta.provider = lib.init d.value.__provider;
-                  };
-              };
             in
-            if parts.right == [ ] then
-              [ (if provName != null then staticDef else d) ]
-            else
-              map (cv: d // { value = cv.value; }) parts.right ++ lib.optional (parts.wrong != [ ]) staticDef;
-          defs' = lib.concatMap (d: if isContentWrapper d then expandContent d else [ d ]) defs;
+            d
+            // {
+              value =
+                d.value
+                # Only narrow what exists: a navigated child carries __provider
+                # with no __contentValues, and inventing an empty one here makes
+                # the wrapper re-flatten to nothing instead of failing loudly.
+                // lib.optionalAttrs (d.value ? __contentValues) { __contentValues = parts.wrong; }
+                // lib.optionalAttrs (parts.right != [ ]) {
+                  includes = (d.value.includes or [ ]) ++ map (cv: cv.value) parts.right;
+                }
+                # Preserve identity: inject name and provider chain from
+                # __provider so aspectSubmodule.merge produces a meaningful
+                # identity instead of an anonymous include index.
+                // lib.optionalAttrs (provName != null) {
+                  name = provName;
+                  meta.provider = lib.init d.value.__provider;
+                };
+            };
+          defs' = map (d: if isContentWrapper d then wrapperToAspect d else d) defs;
           listDefs = builtins.filter (d: builtins.isList d.value) defs';
           policyDefs = builtins.filter (d: builtins.isAttrs d.value && d.value.__isPolicy or false) defs';
         in
@@ -380,7 +397,7 @@ let
                     };
                   }
                 ) parametrics
-                ++ coerceFnDefs nonParametrics
+                ++ coerceBareFnDefs nonParametrics
               )
           else
             let

--- a/nix/lib/aspects/types.nix
+++ b/nix/lib/aspects/types.nix
@@ -26,12 +26,15 @@ let
   # args that is not a NixOS module function. Both sites that pull functions out
   # of a content wrapper (providerType.merge here, wrapChild in normalize.nix for
   # includes elements, which listOf hands over unprocessed) must agree on this.
+  # lib.functionArgs, not builtins: lib.isFunction admits functor-carrying
+  # attrsets, and every merged aspect carries __functor, so the builtin would
+  # throw on any aspect reaching here by alias.
   isParametricContent =
     cv:
     lib.isFunction cv.value
     && (
       let
-        args = builtins.functionArgs cv.value;
+        args = lib.functionArgs cv.value;
       in
       args != { } && !(args ? config) && !(args ? options)
     );
@@ -439,9 +442,16 @@ let
           keyName = lib.last loc;
           # Flatten: if a def value is already wrapped, expand its __contentValues
           # instead of nesting another layer.
+          #
+          # Except once wrapperToAspect has converted it: that keeps the wrapper
+          # whole and moves the parametric definitions into includes, so
+          # __contentValues no longer lists every definition. Expanding such a
+          # value would discard the aspect and the includes with it, leaving only
+          # the static half. A raw wrapper has no name and a converted one always
+          # does, which is what tells them apart.
           flatDefs = lib.concatMap (
             d:
-            if builtins.isAttrs d.value && d.value ? __contentValues then
+            if builtins.isAttrs d.value && d.value ? __contentValues && !(d.value ? name) then
               d.value.__contentValues
             else
               [ { inherit (d) value file; } ]

--- a/nix/lib/aspects/types.nix
+++ b/nix/lib/aspects/types.nix
@@ -156,23 +156,26 @@ let
       meta.loc = lib.mkForce loc;
     };
 
+  # A parametric function reaching aspectSubmodule.merge is evaluated as a NixOS
+  # module and fails on its own context argument, so every def list handed to the
+  # base type passes through here first.
+  coerceFnDefs = map (
+    d:
+    if lib.isFunction d.value && !isSubmoduleFn d.value then
+      d
+      // {
+        value = {
+          includes = [ d.value ];
+        };
+      }
+    else
+      d
+  );
+
   # Merge branch: mixed function + attrset defs — coerce parametric fns to includes.
   mergeMixed =
     baseType: loc: defs:
-    baseType.merge loc (
-      map (
-        d:
-        if lib.isFunction d.value && !isSubmoduleFn d.value then
-          d
-          // {
-            value = {
-              includes = [ d.value ];
-            };
-          }
-        else
-          d
-      ) defs
-    );
+    baseType.merge loc (coerceFnDefs defs);
 
   # Merge branch: all-function defs — submodule fns merge through aspectType,
   # bare parametric fns: single-def returns raw wrapper, multi-def coerces to includes.
@@ -241,18 +244,10 @@ let
           __functor = self: self.__fn;
         }
     else
-      # Multiple bare parametric fns: coerce each to { includes = [fn]; }, merge through aspectType.
-      baseType.merge loc (
-        map (
-          d:
-          d
-          // {
-            value = {
-              includes = [ d.value ];
-            };
-          }
-        ) paramFns
-      );
+      # Multiple bare parametric fns: coerce each to { includes = [fn]; }, merge
+      # through aspectType. paramFns is all-function by construction, so the
+      # mixed branch's coercion is the same operation here.
+      mergeMixed baseType loc paramFns;
 
   providerType =
     typeCfg:
@@ -373,7 +368,7 @@ let
                     };
                   }
                 ) parametrics
-                ++ nonParametrics
+                ++ coerceFnDefs nonParametrics
               )
           else
             let

--- a/nix/lib/aspects/types.nix
+++ b/nix/lib/aspects/types.nix
@@ -22,8 +22,42 @@ let
   # not impossible. If explicit tagging is ever needed, add _type = "den:parametric".
   isParametricWrapper = v: builtins.isAttrs v && v ? __fn && v ? __args;
 
+  # A __contentValues entry holding a parametric function — a function with named
+  # args that is not a NixOS module function. Both sites that pull functions out
+  # of a content wrapper (providerType.merge here, wrapChild in normalize.nix for
+  # includes elements, which listOf hands over unprocessed) must agree on this.
+  isParametricContent =
+    cv:
+    lib.isFunction cv.value
+    && (
+      let
+        args = builtins.functionArgs cv.value;
+      in
+      args != { } && !(args ? config) && !(args ? options)
+    );
+
+  # A loc can hold non-string segments (module-system placeholders); render those
+  # as "<anon>", the same spelling isMeaningfulName rejects.
+  locName = loc: lib.concatStringsSep "." (map (x: if builtins.isString x then x else "<anon>") loc);
+
   isMeaningfulName =
     name: name != "<anon>" && name != "<function body>" && !(lib.hasPrefix "[definition " name);
+
+  # Two __functor definitions at one path cannot be mechanically composed.
+  # Returns the sole functor, or null when there is none.
+  soleFunctor =
+    loc: defs:
+    let
+      withFunctor = builtins.filter (
+        d: builtins.isAttrs (d.value or null) && (d.value or { }) ? __functor
+      ) defs;
+    in
+    if builtins.length withFunctor > 1 then
+      throw "den: multiple __functor definitions at ${locName loc} — merge is ambiguous. Use lib.mkForce to override."
+    else if withFunctor != [ ] then
+      (lib.head withFunctor).value.__functor
+    else
+      null;
 
   # Constructor-stamped names like "<when>" repeat across instances; the
   # child walk indexes them and the gate never keys dedup on them. Both
@@ -48,7 +82,7 @@ let
       inherit (den.lib.aspects.fx.handlers) constantHandler;
       resolveInc =
         inc:
-        if builtins.isAttrs inc && inc ? __fn && inc ? __args then
+        if isParametricWrapper inc then
           let
             fn = inc.__fn;
             fnArgs = inc.__args;
@@ -72,18 +106,7 @@ let
       # Rescue explicit __functor from defs before the submodule merge
       # destroys it (freeform keys become deferred modules).
       # Providers like den.batteries.forward define their own __functor.
-      explicitFunctors = builtins.filter (
-        d: builtins.isAttrs (d.value or null) && (d.value or { }) ? __functor
-      ) defs;
-      originalFunctor =
-        if builtins.length explicitFunctors > 1 then
-          throw "den: multiple __functor definitions at ${
-            lib.concatStringsSep "." (map (x: if builtins.isString x then x else "<anon>") loc)
-          } — merge is ambiguous. Use lib.mkForce to override."
-        else if explicitFunctors != [ ] then
-          (lib.head explicitFunctors).value.__functor
-        else
-          null;
+      originalFunctor = soleFunctor loc defs;
       merged = sub.merge loc (
         defs
         ++ [
@@ -110,9 +133,7 @@ let
       pipeReg = den.quirks or { };
       inherit (den.lib.aspects.fx.keyClassification) structuralKeysSet;
       forwardedSet = lib.genAttrs (builtins.attrNames providesChildren) (_: true);
-      aspectName =
-        merged.name
-          or (lib.concatStringsSep "." (map (x: if builtins.isString x then x else "<anon>") loc));
+      aspectName = merged.name or (locName loc);
       childKeys = builtins.filter (
         k:
         !(structuralKeysSet ? ${k})
@@ -125,9 +146,9 @@ let
         name = "${aspectName}._";
         includes = map (k: merged.${k}) childKeys;
       };
-      # __functor hides synthetic keys from attrValues while making _
-      # usable in includes lists. wrapFunctorChild extracts the thunk
-      # and compile-parametric resolves it to syntheticAspect.
+      # __functor hides the synthetic aspect from attrValues while keeping _
+      # usable in an includes list: wrapChild sees a zero-arg functor and calls
+      # it, so the aspect below is built only when _ is actually included.
       syntheticProvides = providesChildren // {
         __functor = _self: _args: syntheticAspect;
       };
@@ -146,12 +167,8 @@ let
   aspectMeta =
     loc: defs:
     { config, ... }:
-    let
-      locSegments = map (x: if builtins.isString x then x else "<anon>") config.meta.loc;
-      nameFromLoc = lib.concatStringsSep "." locSegments;
-    in
     {
-      meta.name = lib.mkForce nameFromLoc;
+      meta.name = lib.mkForce (locName config.meta.loc);
       meta.file = lib.mkForce (lib.last defs).file;
       meta.loc = lib.mkForce loc;
     };
@@ -262,8 +279,12 @@ let
         builtins.isAttrs v
         || lib.isFunction v
         || (builtins.isList v && builtins.all (i: builtins.isAttrs i && i.__isPolicy or false) v);
+      # Content wrappers are expanded into their constituent defs first, so the
+      # dispatch below sees one def per definition rather than one per key.
       # Merge dispatch:
-      #   parametric wrappers (__fn/__args) → single: preserve wrapper; multi: coerce to includes
+      #   policy list → pass through as-is
+      #   parametric wrappers (__fn/__args) → sole wrapper with no other defs:
+      #     preserve wrapper; otherwise coerce every fn to { includes = [fn]; }
       #   mixed fns + attrsets → coerce parametric fns to { includes = [fn]; }
       #   all fns, has submodule fns → merge through aspectType
       #   all fns, bare parametric only → single: raw wrapper; multi: coerce to includes
@@ -287,15 +308,6 @@ let
               prov = v.__provider or [ ];
             in
             if prov != [ ] then lib.last prov else null;
-          isParametricContent =
-            cv:
-            lib.isFunction cv.value
-            && (
-              let
-                args = builtins.functionArgs cv.value;
-              in
-              args != { } && !(args ? config) && !(args ? options)
-            );
           # A content wrapper holds every definition of its key. Reducing it to
           # one value drops the others with no diagnostic, so expand it into one
           # def per parametric function plus one def carrying the static side.
@@ -373,18 +385,10 @@ let
           else
             let
               nonParametrics = builtins.filter (d: !isParametricWrapper d.value) defs';
-              # Error on conflicting __functor defs (callable aspect factories).
-              # Two factories at the same path is ambiguous — can't be mechanically composed.
-              explicitFunctors = builtins.filter (
-                d: builtins.isAttrs (d.value or null) && (d.value or { }) ? __functor
-              ) nonParametrics;
-              _functorCheck =
-                if builtins.length explicitFunctors > 1 then
-                  throw "den: multiple __functor definitions at ${
-                    lib.concatStringsSep "." (map (x: if builtins.isString x then x else "<anon>") loc)
-                  } — merge is ambiguous. Use lib.mkForce to override."
-                else
-                  null;
+              # Must fire here as well as in mergeWithAspectMeta: the mixed branch
+              # coerces a functor-bearing attrset to { includes = [fn]; }, erasing
+              # __functor before the submodule merge could ever see the conflict.
+              _functorCheck = soleFunctor loc nonParametrics;
               hasFns = builtins.seq _functorCheck (builtins.any (d: lib.isFunction d.value) nonParametrics);
               hasNonFns = builtins.any (d: !lib.isFunction d.value) nonParametrics;
             in
@@ -742,6 +746,7 @@ in
     aspectKeyType
     providerType
     isParametricWrapper
+    isParametricContent
     isSubmoduleFn
     isMeaningfulName
     isSyntheticName

--- a/nix/lib/aspects/types.nix
+++ b/nix/lib/aspects/types.nix
@@ -292,41 +292,45 @@ let
               prov = v.__provider or [ ];
             in
             if prov != [ ] then lib.last prov else null;
-          unwrapContent =
+          isParametricContent =
+            cv:
+            lib.isFunction cv.value
+            && (
+              let
+                args = builtins.functionArgs cv.value;
+              in
+              args != { } && !(args ? config) && !(args ? options)
+            );
+          # A content wrapper holds every definition of its key. Reducing it to
+          # one value drops the others with no diagnostic, so expand it into one
+          # def per parametric function plus one def carrying the static side.
+          # The dispatch below then recombines them through mergeMixed, which is
+          # what handles a fn/attrset mix at an unwrapped key.
+          expandContent =
             d:
             let
-              fns =
-                if d.value ? __contentValues then
-                  builtins.filter (
-                    cv:
-                    lib.isFunction cv.value
-                    && (
-                      let
-                        args = builtins.functionArgs cv.value;
-                      in
-                      args != { } && !(args ? config) && !(args ? options)
-                    )
-                  ) d.value.__contentValues
-                else
-                  [ ];
+              parts = builtins.partition isParametricContent (d.value.__contentValues or [ ]);
               provName = nameFromProvider d.value;
-            in
-            if builtins.length fns == 1 then
-              d // { value = (builtins.head fns).value; }
-            else if provName != null then
               # Preserve identity: inject name and provider chain from
               # __provider so aspectSubmodule.merge produces a meaningful
               # identity instead of an anonymous include index.
-              d
-              // {
-                value = d.value // {
-                  name = provName;
-                  meta.provider = lib.init d.value.__provider;
-                };
-              }
+              staticDef = d // {
+                value =
+                  d.value
+                  // {
+                    __contentValues = parts.wrong;
+                  }
+                  // lib.optionalAttrs (provName != null) {
+                    name = provName;
+                    meta.provider = lib.init d.value.__provider;
+                  };
+              };
+            in
+            if parts.right == [ ] then
+              [ (if provName != null then staticDef else d) ]
             else
-              d;
-          defs' = map (d: if isContentWrapper d then unwrapContent d else d) defs;
+              map (cv: d // { value = cv.value; }) parts.right ++ lib.optional (parts.wrong != [ ]) staticDef;
+          defs' = lib.concatMap (d: if isContentWrapper d then expandContent d else [ d ]) defs;
           listDefs = builtins.filter (d: builtins.isList d.value) defs';
           policyDefs = builtins.filter (d: builtins.isAttrs d.value && d.value.__isPolicy or false) defs';
         in

--- a/templates/ci/modules/deadbugs/nested-key-wrapper-identity.nix
+++ b/templates/ci/modules/deadbugs/nested-key-wrapper-identity.nix
@@ -82,28 +82,91 @@
       }
     );
 
-    # CONTROL: a navigated child carries __provider but no __contentValues, and
-    # nothing may invent an empty one for it — an empty __contentValues
-    # re-flattens to no definitions at all, turning a loud failure into an empty
-    # result. Green on both sides of the fix; it pins the invariant rather than
-    # reproducing a specific break.
-    test-navigated-child-keeps-no-content-values = denTest (
-      { den, igloo, ... }:
+    # An annotated child three levels down carries __provider and no
+    # __contentValues of its own. Nothing may invent an empty one when it passes
+    # through providerType: rawHasCV pins that the child starts without one, so
+    # the test cannot pass by accident on a shallower shape whose middle name IS
+    # the nested key and therefore has one already.
+    test-annotated-child-gains-no-content-values = denTest (
+      { den, ... }:
       {
         den.hosts.x86_64-linux.igloo.users.tux = { };
 
-        den.aspects.mid._.net.nixos.boot.kernelParams = [ "net-param" ];
-
-        den.aspects.igloo.includes = [ den.aspects.mid._.net ];
+        den.aspects.libraries.services.network.cilium.nixos.boot.kernelParams = [ "s-cil" ];
+        den.aspects.mid._.net = den.aspects.libraries.services.network;
 
         expr = {
-          invented = den.aspects.mid._.net ? __contentValues;
-          applied = builtins.filter (p: p == "net-param") igloo.boot.kernelParams;
+          rawHasCV = den.aspects.libraries.services.network ? __contentValues;
+          hopHasCV = den.aspects.mid._.net ? __contentValues;
         };
         expected = {
-          invented = false;
-          applied = [ "net-param" ];
+          rawHasCV = false;
+          hopHasCV = false;
         };
+      }
+    );
+
+    # A mixed wrapper re-exported through a providerType hop and then assigned to
+    # a nested key. The flatten must not expand an already-converted aspect back
+    # into its definitions — doing so discards the includes the parametric half
+    # was moved into, keeping only the static side.
+    test-mixed-wrapper-reexport = denTest (
+      {
+        den,
+        lib,
+        igloo,
+        ...
+      }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        imports = [
+          {
+            den.aspects.libraries.alpha =
+              { host, ... }:
+              {
+                nixos.boot.kernelParams = [ "a=${host.hostName}" ];
+              };
+          }
+          {
+            den.aspects.libraries.alpha.nixos.boot.kernelParams = [ "s" ];
+          }
+        ];
+
+        den.aspects.mid._.thing = den.aspects.libraries.alpha;
+        den.aspects.consumer.child = den.aspects.mid._.thing;
+
+        den.aspects.igloo.includes = [ den.aspects.consumer.child ];
+
+        expr = builtins.sort (a: b: a < b) (
+          builtins.filter (p: lib.hasPrefix "a=" p || p == "s") igloo.boot.kernelParams
+        );
+        expected = [
+          "a=igloo"
+          "s"
+        ];
+      }
+    );
+
+    # Aliasing a merged aspect: every merged aspect carries __functor, so a
+    # functor-blind functionArgs throws on the alias.
+    test-alias-merged-aspect = denTest (
+      {
+        den,
+        lib,
+        igloo,
+        ...
+      }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.base.nixos.boot.kernelParams = [ "s-base" ];
+        den.aspects.libraries.alias = den.aspects.base;
+
+        den.aspects.igloo.includes = [ den.aspects.libraries.alias ];
+
+        expr = builtins.filter (lib.hasPrefix "s-") igloo.boot.kernelParams;
+        expected = [ "s-base" ];
       }
     );
 

--- a/templates/ci/modules/deadbugs/nested-key-wrapper-identity.nix
+++ b/templates/ci/modules/deadbugs/nested-key-wrapper-identity.nix
@@ -1,0 +1,144 @@
+# A nested aspect key carries its identity on the content wrapper, via
+# __provider. Anything that takes definitions out of the wrapper has to keep
+# that identity, or the definitions resolve to an anonymous per-inclusion name,
+# gate dedup stops matching them, and their content lands once per include path.
+{ denTest, ... }:
+{
+  flake.tests.deadbugs.nested-key-wrapper-identity = {
+
+    # All definitions parametric — the wrapper is the only identity carrier.
+    test-all-parametric-nested-key-dedups = denTest (
+      {
+        den,
+        lib,
+        igloo,
+        ...
+      }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.libraries.alpha =
+          { host, ... }:
+          {
+            nixos.boot.kernelParams = [ "from-${host.hostName}" ];
+          };
+
+        den.aspects.parent1.includes = [ den.aspects.libraries.alpha ];
+        den.aspects.parent2.includes = [ den.aspects.libraries.alpha ];
+
+        den.aspects.igloo.includes = [
+          den.aspects.parent1
+          den.aspects.parent2
+        ];
+
+        expr = builtins.filter (lib.hasPrefix "from-") igloo.boot.kernelParams;
+        expected = [ "from-igloo" ];
+      }
+    );
+
+    # Two parametric definitions of one nested key, reached by two paths.
+    test-multi-parametric-nested-key-dedups = denTest (
+      {
+        den,
+        lib,
+        igloo,
+        ...
+      }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        imports = [
+          {
+            den.aspects.libraries.alpha =
+              { host, ... }:
+              {
+                nixos.boot.kernelParams = [ "a-${host.hostName}" ];
+              };
+          }
+          {
+            den.aspects.libraries.alpha =
+              { user, ... }:
+              {
+                nixos.boot.kernelParams = [ "b-${user.userName}" ];
+              };
+          }
+        ];
+
+        den.aspects.parent1.includes = [ den.aspects.libraries.alpha ];
+        den.aspects.parent2.includes = [ den.aspects.libraries.alpha ];
+
+        den.aspects.igloo.includes = [
+          den.aspects.parent1
+          den.aspects.parent2
+        ];
+
+        expr = builtins.sort (a: b: a < b) (
+          builtins.filter (p: lib.hasPrefix "a-" p || lib.hasPrefix "b-" p) igloo.boot.kernelParams
+        );
+        expected = [
+          "a-igloo"
+          "b-tux"
+        ];
+      }
+    );
+
+    # CONTROL: a navigated child carries __provider but no __contentValues, and
+    # nothing may invent an empty one for it — an empty __contentValues
+    # re-flattens to no definitions at all, turning a loud failure into an empty
+    # result. Green on both sides of the fix; it pins the invariant rather than
+    # reproducing a specific break.
+    test-navigated-child-keeps-no-content-values = denTest (
+      { den, igloo, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.mid._.net.nixos.boot.kernelParams = [ "net-param" ];
+
+        den.aspects.igloo.includes = [ den.aspects.mid._.net ];
+
+        expr = {
+          invented = den.aspects.mid._.net ? __contentValues;
+          applied = builtins.filter (p: p == "net-param") igloo.boot.kernelParams;
+        };
+        expected = {
+          invented = false;
+          applied = [ "net-param" ];
+        };
+      }
+    );
+
+    # CONTROL: a providerType hop (_ slot) included from a nested key — both
+    # halves survive the hop. Green before and after.
+    test-underscore-hop-then-nested-key = denTest (
+      {
+        den,
+        lib,
+        igloo,
+        ...
+      }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.source._.slot =
+          { host, ... }:
+          {
+            nixos.boot.kernelParams = [ "param-${host.hostName}" ];
+          };
+
+        den.aspects.middle.hop.includes = [ den.aspects.source._.slot ];
+        den.aspects.middle.hop.nixos.boot.kernelParams = [ "static" ];
+
+        den.aspects.igloo.includes = [ den.aspects.middle.hop ];
+
+        expr = builtins.sort (a: b: a < b) (
+          builtins.filter (p: lib.hasPrefix "param-" p || p == "static") igloo.boot.kernelParams
+        );
+        expected = [
+          "param-igloo"
+          "static"
+        ];
+      }
+    );
+
+  };
+}

--- a/templates/ci/modules/deadbugs/parametric-wrapper-beside-content-wrapper.nix
+++ b/templates/ci/modules/deadbugs/parametric-wrapper-beside-content-wrapper.nix
@@ -1,0 +1,96 @@
+# A key defined once from a bare parametric aspect (a __fn/__args wrapper) and
+# once from a nested aspect key (a content wrapper holding a function).
+# providerType.merge's parametric branch coerces the wrapper's __fn to includes
+# but concatenates the other definitions raw.
+{ denTest, ... }:
+{
+  flake.tests.deadbugs.parametric-wrapper-beside-content-wrapper = {
+
+    # One function inside the content wrapper.
+    test-wrapper-plus-single-fn-content = denTest (
+      { den, igloo, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        # A provides child holding a bare parametric function stays a raw
+        # __fn/__args wrapper — `provides` is providerType with no coercion.
+        den.aspects.holder._.bare =
+          { user, ... }:
+          {
+            nixos.environment.etc."from-bare".text = user.userName;
+          };
+
+        den.aspects.libraries.child =
+          { host, ... }:
+          {
+            nixos.environment.etc."from-child".text = host.hostName;
+          };
+
+        imports = [
+          { den.aspects.foo = den.aspects.holder._.bare; }
+          { den.aspects.foo = den.aspects.libraries.child; }
+        ];
+
+        den.aspects.igloo.includes = [ den.aspects.foo ];
+
+        expr = {
+          bare = igloo.environment.etc."from-bare".text or "<dropped>";
+          child = igloo.environment.etc."from-child".text or "<dropped>";
+        };
+        expected = {
+          bare = "tux";
+          child = "igloo";
+        };
+      }
+    );
+
+    # Two functions inside the content wrapper.
+    test-wrapper-plus-two-fn-content = denTest (
+      { den, igloo, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        # A provides child holding a bare parametric function stays a raw
+        # __fn/__args wrapper — `provides` is providerType with no coercion.
+        den.aspects.holder._.bare =
+          { user, ... }:
+          {
+            nixos.environment.etc."from-bare".text = user.userName;
+          };
+
+        imports = [
+          {
+            den.aspects.libraries.child =
+              { host, ... }:
+              {
+                nixos.environment.etc."from-child".text = host.hostName;
+              };
+          }
+          {
+            den.aspects.libraries.child =
+              { user, ... }:
+              {
+                nixos.environment.etc."from-child-2".text = user.userName;
+              };
+          }
+          { den.aspects.foo = den.aspects.holder._.bare; }
+          { den.aspects.foo = den.aspects.libraries.child; }
+        ];
+
+        den.aspects.igloo.includes = [ den.aspects.foo ];
+
+        expr = {
+          bare = igloo.environment.etc."from-bare".text or "<dropped>";
+          child = igloo.environment.etc."from-child".text or "<dropped>";
+          child2 = igloo.environment.etc."from-child-2".text or "<dropped>";
+        };
+        expected = {
+          bare = "tux";
+          child = "igloo";
+          child2 = "tux";
+        };
+      }
+    );
+
+  };
+}

--- a/templates/ci/modules/deadbugs/quirk-set-and-consume-same-aspect.nix
+++ b/templates/ci/modules/deadbugs/quirk-set-and-consume-same-aspect.nix
@@ -1,11 +1,16 @@
 # User report (second claim): setting a quirk value in the SAME aspect that
-# consumes the quirk silently drops the value. Setting it from a different
-# aspect works.
+# consumes the quirk silently drops the value.
+#
+# That diagnosis does not hold — the three same-aspect cases below were already
+# green. The dropped value was the merge defect covered by
+# samename-mixed-merge-drop: the quirk sat in a static definition that a
+# parametric definition of the same name displaced. Kept as a regression guard
+# for both the misattribution and the real cause.
 { denTest, lib, ... }:
 {
   flake.tests.deadbugs.quirk-set-and-consume-same-aspect = {
 
-    # FAILING: producer and consumer are the same aspect.
+    # Producer and consumer are the same aspect.
     test-same-aspect-set-and-consume = denTest (
       { den, igloo, ... }:
       {

--- a/templates/ci/modules/deadbugs/quirk-set-and-consume-same-aspect.nix
+++ b/templates/ci/modules/deadbugs/quirk-set-and-consume-same-aspect.nix
@@ -1,0 +1,139 @@
+# User report (second claim): setting a quirk value in the SAME aspect that
+# consumes the quirk silently drops the value. Setting it from a different
+# aspect works.
+{ denTest, lib, ... }:
+{
+  flake.tests.deadbugs.quirk-set-and-consume-same-aspect = {
+
+    # FAILING: producer and consumer are the same aspect.
+    test-same-aspect-set-and-consume = denTest (
+      { den, igloo, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+        den.quirks.persist = {
+          description = "Paths to persist";
+        };
+
+        den.aspects.libraries.alpha = {
+          persist.directories = [ "/var/lib/alpha" ];
+          nixos =
+            { persist, ... }:
+            {
+              environment.etc."persisted".text = lib.concatStringsSep "," (
+                lib.concatMap (p: p.directories or [ ]) persist
+              );
+            };
+        };
+
+        den.aspects.igloo.includes = [ den.aspects.libraries.alpha ];
+
+        expr = igloo.environment.etc."persisted".text or "<dropped>";
+        expected = "/var/lib/alpha";
+      }
+    );
+
+    # CONTROL: producer is a separate aspect — the documented working path.
+    test-separate-aspect-set-and-consume = denTest (
+      { den, igloo, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+        den.quirks.persist = {
+          description = "Paths to persist";
+        };
+
+        den.aspects.libraries.producer.persist.directories = [ "/var/lib/alpha" ];
+
+        den.aspects.libraries.alpha.nixos =
+          { persist, ... }:
+          {
+            environment.etc."persisted".text = lib.concatStringsSep "," (
+              lib.concatMap (p: p.directories or [ ]) persist
+            );
+          };
+
+        den.aspects.igloo.includes = [
+          den.aspects.libraries.producer
+          den.aspects.libraries.alpha
+        ];
+
+        expr = igloo.environment.etc."persisted".text or "<dropped>";
+        expected = "/var/lib/alpha";
+      }
+    );
+
+    # Both: same aspect sets its own value AND a sibling contributes.
+    test-same-aspect-plus-sibling = denTest (
+      { den, igloo, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+        den.quirks.persist = {
+          description = "Paths to persist";
+        };
+
+        den.aspects.libraries.producer.persist.directories = [ "/var/lib/producer" ];
+
+        den.aspects.libraries.alpha = {
+          persist.directories = [ "/var/lib/alpha" ];
+          nixos =
+            { persist, ... }:
+            {
+              environment.etc."persisted".text = lib.concatStringsSep "," (
+                lib.sort (a: b: a < b) (lib.concatMap (p: p.directories or [ ]) persist)
+              );
+            };
+        };
+
+        den.aspects.igloo.includes = [
+          den.aspects.libraries.producer
+          den.aspects.libraries.alpha
+        ];
+
+        expr = igloo.environment.etc."persisted".text or "<dropped>";
+        expected = "/var/lib/alpha,/var/lib/producer";
+      }
+    );
+
+    # The reporter's quirk symptom, predicted to be the same defect as
+    # samename-mixed-merge-drop: the aspect has a parametric definition
+    # alongside a static one, and the static one carries the quirk value.
+    test-quirk-value-in-static-def-beside-parametric-def = denTest (
+      { den, igloo, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+        den.quirks.persist = {
+          description = "Paths to persist";
+        };
+
+        imports = [
+          {
+            den.aspects.libraries.alpha =
+              { host, ... }:
+              {
+                nixos.environment.etc."hostname-marker".text = host.hostName;
+              };
+          }
+          {
+            den.aspects.libraries.alpha.persist.directories = [ "/var/lib/alpha" ];
+          }
+        ];
+
+        den.aspects.libraries.consumer.nixos =
+          { persist, ... }:
+          {
+            environment.etc."persisted".text = lib.concatStringsSep "," (
+              lib.concatMap (p: p.directories or [ ]) persist
+            );
+          };
+
+        den.aspects.igloo.includes = [
+          den.aspects.libraries.alpha
+          den.aspects.libraries.consumer
+        ];
+
+        expr = igloo.environment.etc."persisted".text or "<dropped>";
+        expected = "/var/lib/alpha";
+      }
+    );
+
+  };
+}

--- a/templates/ci/modules/deadbugs/samename-mixed-merge-drop.nix
+++ b/templates/ci/modules/deadbugs/samename-mixed-merge-drop.nix
@@ -1,0 +1,253 @@
+# User report: an aspect declared under the SAME name in two files loses one
+# definition's class content when one definition is a parametric function
+# (`{ user, ... }: { nixos = ...; }`) and the other a plain attrset
+# (`{ nixos = ...; }`). Renaming either definition restores both.
+#
+# Reporter expects same-name definitions to merge, which they do when both
+# definitions have the same shape.
+{ denTest, ... }:
+{
+  flake.tests.deadbugs.samename-mixed-merge-drop = {
+
+    # FAILING: parametric fn + static attrset at the same nested aspect name.
+    test-parametric-plus-static-both-emit = denTest (
+      { den, igloo, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        imports = [
+          {
+            den.aspects.libraries.alpha =
+              { user, ... }:
+              {
+                nixos.environment.etc."from-parametric".text = user.userName;
+              };
+          }
+          {
+            den.aspects.libraries.alpha.nixos.environment.etc."from-static".text = "static";
+          }
+        ];
+
+        den.aspects.igloo.includes = [ den.aspects.libraries.alpha ];
+
+        expr = {
+          parametric = igloo.environment.etc."from-parametric".text or "<dropped>";
+          static = igloo.environment.etc."from-static".text or "<dropped>";
+        };
+        expected = {
+          parametric = "tux";
+          static = "static";
+        };
+      }
+    );
+
+    # Same shape, but the parametric definition's class value is itself a
+    # module function — the reporter's exact layering.
+    test-parametric-with-class-module-plus-static = denTest (
+      { den, igloo, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        imports = [
+          {
+            den.aspects.libraries.alpha =
+              { user, ... }:
+              {
+                nixos =
+                  { lib, ... }:
+                  {
+                    environment.etc."from-parametric".text = lib.toUpper user.userName;
+                  };
+              };
+          }
+          {
+            den.aspects.libraries.alpha.nixos.environment.etc."from-static".text = "static";
+          }
+        ];
+
+        den.aspects.igloo.includes = [ den.aspects.libraries.alpha ];
+
+        expr = {
+          parametric = igloo.environment.etc."from-parametric".text or "<dropped>";
+          static = igloo.environment.etc."from-static".text or "<dropped>";
+        };
+        expected = {
+          parametric = "TUX";
+          static = "static";
+        };
+      }
+    );
+
+    # CONTROL: parametric definition asks for `host`, not `user`.
+    test-parametric-host-arg-plus-static = denTest (
+      { den, igloo, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        imports = [
+          {
+            den.aspects.libraries.alpha =
+              { host, ... }:
+              {
+                nixos.environment.etc."from-parametric".text = host.hostName;
+              };
+          }
+          {
+            den.aspects.libraries.alpha.nixos.environment.etc."from-static".text = "static";
+          }
+        ];
+
+        den.aspects.igloo.includes = [ den.aspects.libraries.alpha ];
+
+        expr = {
+          parametric = igloo.environment.etc."from-parametric".text or "<dropped>";
+          static = igloo.environment.etc."from-static".text or "<dropped>";
+        };
+        expected = {
+          parametric = "igloo";
+          static = "static";
+        };
+      }
+    );
+
+    # CONTROL: both definitions static — the merge the reporter says works.
+    test-static-plus-static-both-emit = denTest (
+      { den, igloo, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        imports = [
+          {
+            den.aspects.libraries.alpha.nixos.environment.etc."from-a".text = "a";
+          }
+          {
+            den.aspects.libraries.alpha.nixos.environment.etc."from-b".text = "b";
+          }
+        ];
+
+        den.aspects.igloo.includes = [ den.aspects.libraries.alpha ];
+
+        expr = {
+          a = igloo.environment.etc."from-a".text or "<dropped>";
+          b = igloo.environment.etc."from-b".text or "<dropped>";
+        };
+        expected = {
+          a = "a";
+          b = "b";
+        };
+      }
+    );
+
+    # Blast radius: same mix at a TOP-LEVEL aspect name rather than a nested
+    # key, which reaches providerType.merge without a content wrapper.
+    test-toplevel-parametric-plus-static = denTest (
+      { den, igloo, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        imports = [
+          {
+            den.aspects.alpha =
+              { host, ... }:
+              {
+                nixos.environment.etc."from-parametric".text = host.hostName;
+              };
+          }
+          {
+            den.aspects.alpha.nixos.environment.etc."from-static".text = "static";
+          }
+        ];
+
+        den.aspects.igloo.includes = [ den.aspects.alpha ];
+
+        expr = {
+          parametric = igloo.environment.etc."from-parametric".text or "<dropped>";
+          static = igloo.environment.etc."from-static".text or "<dropped>";
+        };
+        expected = {
+          parametric = "igloo";
+          static = "static";
+        };
+      }
+    );
+
+    # Two parametric definitions plus a static one. This flips which side is
+    # lost: the static definition survives and BOTH parametric ones vanish,
+    # because the collapse takes its other branch.
+    test-two-parametric-plus-static-both-emit = denTest (
+      { den, igloo, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        imports = [
+          {
+            den.aspects.libraries.alpha =
+              { host, ... }:
+              {
+                nixos.environment.etc."from-parametric".text = host.hostName;
+              };
+          }
+          {
+            den.aspects.libraries.alpha =
+              { user, ... }:
+              {
+                nixos.environment.etc."from-parametric-2".text = user.userName;
+              };
+          }
+          {
+            den.aspects.libraries.alpha.nixos.environment.etc."from-static".text = "static";
+          }
+        ];
+
+        den.aspects.igloo.includes = [ den.aspects.libraries.alpha ];
+
+        expr = {
+          parametric = igloo.environment.etc."from-parametric".text or "<dropped>";
+          parametric2 = igloo.environment.etc."from-parametric-2".text or "<dropped>";
+          static = igloo.environment.etc."from-static".text or "<dropped>";
+        };
+        expected = {
+          parametric = "igloo";
+          parametric2 = "tux";
+          static = "static";
+        };
+      }
+    );
+
+    # CONTROL: the reporter's workaround — distinct names, both included.
+    test-distinct-names-both-emit = denTest (
+      { den, igloo, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        imports = [
+          {
+            den.aspects.libraries.alpha =
+              { user, ... }:
+              {
+                nixos.environment.etc."from-parametric".text = user.userName;
+              };
+          }
+          {
+            den.aspects.libraries.beta.nixos.environment.etc."from-static".text = "static";
+          }
+        ];
+
+        den.aspects.igloo.includes = [
+          den.aspects.libraries.alpha
+          den.aspects.libraries.beta
+        ];
+
+        expr = {
+          parametric = igloo.environment.etc."from-parametric".text or "<dropped>";
+          static = igloo.environment.etc."from-static".text or "<dropped>";
+        };
+        expected = {
+          parametric = "tux";
+          static = "static";
+        };
+      }
+    );
+
+  };
+}


### PR DESCRIPTION
## Report

An aspect declared under the same name in two files lost one file's config. From the user report:

> A couple days ago I moved my config to den. Now I've noticed that my rollback service no longer exists. The problem seems to be that I was using the same aspect name for both. When I rename the rollback script aspect from `den.aspects.libraries.preservation` to `den.aspects.libraries.rollback` it works.

One file defined `den.aspects.libraries.preservation` as a parametric function (`{ user, ... }: { nixos = ...; }`), the other as a plain attrset. The attrset side vanished silently — no error, no warning.

## Root cause

A nested aspect key collects all of its definitions in a content wrapper's `__contentValues`. `providerType.merge` reduced that wrapper to a single definition before dispatch: with exactly one parametric function among the definitions it took that function and discarded every static attrset; otherwise it passed the wrapper through, whose forwarded attrs carry only the static side, discarding every function. Either way one side was lost with no diagnostic.

`mergeMixed` already handles a fn/attrset mix correctly by coercing functions to `includes` — it was never reached, because the collapse ran first.

Scope, as tested rather than assumed: top-level aspect names are unaffected, and so is a `_`-provides sub-aspect **declared inline** (what `issue-448-mixed-merge.nix` covers). A `_` slot assigned from a nested aspect key does route through this path. The defect is not specific to the `user` argument — a `{ host, ... }` definition drops the static side identically.

## Fix

Keep the content wrapper as a single definition and move its parametric definitions into `includes` — the shape `wrapChild` already produces for an includes element, which `listOf` hands over without reaching this merge. Both sides survive, and identity injection applies unconditionally because there is exactly one def to carry it.

An earlier revision of this branch split the wrapper into one def per definition. Review found that this loses `__provider` identity whenever every definition is parametric, trading the silent drop for silent duplication — content landing once per include path. That is fixed here and pinned by tests.

## Also fixed in this branch

**Bare parametric functions in the parametric branch** (`d77091de`). That branch coerced `__fn` wrappers to `includes` but concatenated the remaining defs raw, so a bare parametric function reached `aspectSubmodule.merge` and died with `attribute 'host' missing`. Verified pre-existing: the repro fails at `6cc4153a` too, because the old collapse also emitted a bare function whenever a wrapper held exactly one. The expansion only changed the multi-function shape — silent drop before, that same error after.

**Invented `__contentValues`** — a navigated child carries `__provider` with no `__contentValues`; giving it an empty one makes it re-flatten to nothing instead of failing.

**Coercion domain** — `lib.isFunction` is true for any attrset with `__functor`, and every merged aspect has one, so sharing one coercion demoted ordinary aspect-valued defs to `includes`. The parametric branch now uses `builtins.isFunction`, which matches exactly the bare lambda that can reach the module system as a module.

## Simplification (`09693d74`)

No behaviour change: `isParametricContent`, `soleFunctor`, and `locName` each existed in two-to-four verbatim copies across `types.nix` and `normalize.nix`; `resolveInc` re-inlined `isParametricWrapper`. Two comments that no longer described the code are corrected. Both `__functor` ambiguity checks are kept deliberately — the mixed branch erases `__functor` before the submodule merge could see the conflict.

## Tests

- `samename-mixed-merge-drop.nix` — the reported shapes plus controls for static+static, distinct names, and a top-level aspect name.
- `nested-key-wrapper-identity.nix` — identity/dedup for all-parametric nested keys; two tests red before the final commit, two controls green throughout.
- `parametric-wrapper-beside-content-wrapper.nix` — the bare-function-in-parametric-branch regression.
- `quirk-set-and-consume-same-aspect.nix` — the reporter also suspected quirks, believing that setting a quirk in the aspect that consumes it was dropped. That diagnosis does not hold: those cases were already green. Their quirk symptom was this merge defect, the value sitting in the static definition that the parametric one displaced.

## Verification

`just ci` 1101/1101 · `just all check` (8 templates) · `just check-noflake` · `just unit` · `just fmt` clean.