### PR TITLE
fix: collapse agreeing definitions in the route merge (#674)

### DIFF
--- a/nix/lib/aspects/fx/edges/route.nix
+++ b/nix/lib/aspects/fx/edges/route.nix
@@ -40,11 +40,11 @@ let
   # via the closure each edge carries.
 
   # Freeform type for route nesting evalModules: merges like NixOS (attrsets
-  # deep-merge, lists concatenate) but errors on conflicting scalar/derivation
-  # values instead of silently clobbering.
+  # deep-merge, lists concatenate, equal values collapse) but errors on
+  # disagreeing scalar/derivation values instead of silently clobbering.
   mergeableType = lib.mkOptionType {
     name = "mergeable";
-    description = "auto-merged value (attrsets merge, lists concatenate, scalars conflict)";
+    description = "auto-merged value (attrsets merge, lists concatenate, scalars must agree)";
     merge =
       loc: defs:
       let
@@ -60,6 +60,10 @@ let
         builtins.concatLists values
       else if allMergeableAttrs then
         (lib.types.lazyAttrsOf mergeableType).merge loc defs
+      # Agreeing definitions are not a conflict — same rule as NixOS's
+      # `mergeEqualOption`. Checked last: it forces the values.
+      else if builtins.all (v: v == first) values then
+        first
       else
         throw "den: the option `${lib.showOption loc}' has conflicting definitions from multiple aspects";
   };

--- a/templates/ci/modules/deadbugs/issue-674-identical-values-merge.nix
+++ b/templates/ci/modules/deadbugs/issue-674-identical-values-merge.nix
@@ -39,8 +39,11 @@
           den.aspects.pkg-two
         ];
 
-        expr = builtins.readFile config.flake.packages.x86_64-linux.shared;
-        expected = "same";
+        # Forcing the merged option is the whole oracle — before the fix this
+        # threw. Reading the file would realise an x86_64-linux derivation and
+        # fail the macOS runner on platform mismatch.
+        expr = config.flake.packages.x86_64-linux.shared.name;
+        expected = "shared";
       }
     );
 

--- a/templates/ci/modules/deadbugs/issue-674-identical-values-merge.nix
+++ b/templates/ci/modules/deadbugs/issue-674-identical-values-merge.nix
@@ -1,0 +1,124 @@
+# Issue #674: identical values from multiple aspects must merge, not conflict.
+#
+# route.nix's `mergeableType` deep-merges attrsets and concatenates lists, but
+# anything else (scalars, derivations) hit the conflict throw — even when every
+# definition was the same value. NixOS's own `mergeEqualOption` accepts equal
+# definitions, so `enable = true` in two aspects broke where plain NixOS is fine.
+{ denTest, inputs, ... }:
+{
+  imports = [ inputs.den.flakeOutputs.packages ];
+
+  flake.tests.deadbugs-issue-674 = {
+
+    # Two aspects producing the same derivation at the same key.
+    test-identical-derivations-merge = denTest (
+      {
+        config,
+        den,
+        ...
+      }:
+      {
+        imports = [ inputs.den.flakeOutputs.packages ];
+
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.pkg-one.packages =
+          { pkgs, ... }:
+          {
+            shared = pkgs.writeText "shared" "same";
+          };
+
+        den.aspects.pkg-two.packages =
+          { pkgs, ... }:
+          {
+            shared = pkgs.writeText "shared" "same";
+          };
+
+        den.schema.flake-system.includes = [
+          den.aspects.pkg-one
+          den.aspects.pkg-two
+        ];
+
+        expr = builtins.readFile config.flake.packages.x86_64-linux.shared;
+        expected = "same";
+      }
+    );
+
+    # The reported symptom: the same scalar set by two aspects. Deep-merging the
+    # app attrset descends to `type`/`program`, which have two defs apiece.
+    test-identical-scalars-merge = denTest (
+      {
+        config,
+        den,
+        inputs,
+        ...
+      }:
+      {
+        imports = [ inputs.den.flakeOutputs.apps ];
+
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.app-one.apps =
+          { pkgs, ... }:
+          {
+            shared = {
+              type = "app";
+              program = "${pkgs.hello}/bin/hello";
+            };
+          };
+
+        den.aspects.app-two.apps =
+          { pkgs, ... }:
+          {
+            shared = {
+              type = "app";
+              program = "${pkgs.hello}/bin/hello";
+            };
+          };
+
+        den.schema.flake-system.includes = [
+          den.aspects.app-one
+          den.aspects.app-two
+        ];
+
+        expr = config.flake.apps.x86_64-linux.shared.type;
+        expected = "app";
+      }
+    );
+
+    # Negative control: disagreeing definitions must still be a hard conflict.
+    test-conflicting-values-still-throw = denTest (
+      {
+        config,
+        den,
+        ...
+      }:
+      {
+        imports = [ inputs.den.flakeOutputs.packages ];
+
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.pkg-one.packages =
+          { pkgs, ... }:
+          {
+            shared = pkgs.writeText "shared" "one";
+          };
+
+        den.aspects.pkg-two.packages =
+          { pkgs, ... }:
+          {
+            shared = pkgs.writeText "shared" "two";
+          };
+
+        den.schema.flake-system.includes = [
+          den.aspects.pkg-one
+          den.aspects.pkg-two
+        ];
+
+        expr =
+          (builtins.tryEval (builtins.seq config.flake.packages.x86_64-linux.shared.outPath true)).success;
+        expected = false;
+      }
+    );
+  };
+}


### PR DESCRIPTION
Closes #674

## Summary

`mergeableType` — the freeform type route nesting evaluates modules under — deep-merges attrsets, concatenates lists, and throws on everything else. Derivations are deliberately excluded from the attrset branch so they stay opaque, so two aspects producing the same package fell to the conflict throw even though the definitions agreed. Same for the reported `enable = true` shape, where deep-merging descends to a scalar leaf with two definitions.

- Accepts all-equal definitions before the conflict throw, matching NixOS's `mergeEqualOption`. Checked last, so it forces values only on the path that already threw.

#574 introduced the type claiming NixOS module semantics, but `mergeEqualOption` accepts agreeing definitions and only throws on disagreement — so the divergence is latent from #574, and #671 made the path reachable, which is the reporter's own reading of the bisect. This is the same collapse-agreeing-definitions rule #671 applied to `meta.provider`, now on the route freeform type.

Testing:

- Adds the reported case verbatim (two aspects, one shared derivation), the reported symptom shape (a scalar leaf reached by deep-merging an `apps` attrset defined by two aspects), and a negative control pinning that disagreeing definitions still throw.

## Validation

- `nix develop -c just ci`: 1118/1118, exit 0, zero failures and zero errors. `nix develop -c just fmt` a no-op at the final rev.
- Reproduced first on an unfixed `origin/main` worktree at 36c8ba5c: the issue's test verbatim fails with `den: the option 'shared' has conflicting definitions from multiple aspects`, so the fix is measured against a red baseline rather than a green assumption.
- Probed the negative control rather than trusting its pass. Forcing the value without `tryEval` prints that same conflict error, so it fails for the guard's reason and not incidentally.
- Confirmed the new suite is discovered by the CI harness with `just ci deadbugs-issue-674` (3/3). The background `just ci` log truncates to 42 lines, so the suite's absence from that log is not evidence either way and was not read as such.

## Known limitation

The equality check cannot reach function-valued leaves. Measured against this nixpkgs:

| expression | result |
| --- | --- |
| `(x: x) == (x: x)` | `false` |
| `let f = x: x; in f == f` | `false` |
| `{ a = 1; f = x: x; } == { a = 1; f = x: x; }` | `false` |

A lambda never compares equal, not even to itself, and one lambda anywhere in an attrset makes the whole comparison false. So two aspects delivering the same *function* at one option still conflict, and no `==`-level rule can fix that — it needs identity carried alongside the value. Derivations are unaffected because Nix short-circuits their comparison on `outPath`, which is why the reported case is fully fixable here.
